### PR TITLE
Update ProgressRing strokeDashoffset

### DIFF
--- a/frontend/src/features/goals/components/GoalProgress/ProgressRing.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/ProgressRing.tsx
@@ -21,12 +21,12 @@ export const ProgressRing: React.FC<ProgressRingProps> = ({
   className = '',
   children,
 }) => {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = radius * 2 * Math.PI;
-  const strokeDashoffset = circumference - (progress / 100) * circumference;
-  
   // Ensure progress is between 0 and 100
   const safeProgress = Math.min(Math.max(progress, 0), 100);
+
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const strokeDashoffset = circumference - (safeProgress / 100) * circumference;
 
   return (
     <div className={`relative inline-flex items-center justify-center ${className}`}>


### PR DESCRIPTION
## Summary
- compute `safeProgress` first
- use `safeProgress` when calculating `strokeDashoffset`

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run type-check`
- `make test` *(fails: ModuleNotFoundError: No module named 'get_user_profile.handler')*
- `make lint` *(fails: Module not installed for terraform)*

------
https://chatgpt.com/codex/tasks/task_e_686ef554e7b883289cc54017379b4f50