### PR TITLE
Add IndexedDB journal storage sample

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
         "eslint": "^9.29.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "fake-indexeddb": "^6.0.1",
         "globals": "^16.2.0",
         "happy-dom": "^15.0.0",
         "postcss": "^8.5.1",
@@ -4829,6 +4830,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "fake-indexeddb": "^6.0.1",
     "globals": "^16.2.0",
     "happy-dom": "^15.0.0",
     "postcss": "^8.5.1",

--- a/frontend/src/features/journal/components/JournalStorageSample.tsx
+++ b/frontend/src/features/journal/components/JournalStorageSample.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import JournalEditor from './JournalEditor';
+import { JournalEntry, getAllEntries, addEntry, updateEntry, deleteEntry } from '../hooks/useJournalStorage';
+import { Button } from '@/components/common';
+
+const JournalStorageSample: React.FC = () => {
+  const [entries, setEntries] = useState<JournalEntry[]>([]);
+  const [current, setCurrent] = useState<JournalEntry | null>(null);
+
+  const loadEntries = async () => {
+    const all = await getAllEntries();
+    setEntries(all);
+  };
+
+  useEffect(() => {
+    loadEntries();
+  }, []);
+
+  const handleSave = async (markdown: string) => {
+    if (current?.id) {
+      await updateEntry({ ...current, content: markdown });
+    } else {
+      const created = await addEntry(markdown);
+      setCurrent(created);
+    }
+    await loadEntries();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteEntry(id);
+    if (current?.id === id) setCurrent(null);
+    await loadEntries();
+  };
+
+  return (
+    <div className="flex gap-4">
+      <div className="w-1/3 space-y-2">
+        <Button type="button" onClick={() => setCurrent({ content: '' })}>
+          New Entry
+        </Button>
+        <ul className="space-y-1">
+          {entries.map((e) => (
+            <li key={e.id} className="flex justify-between items-center border p-2 rounded">
+              <button type="button" onClick={() => setCurrent(e)} className="text-left flex-1">
+                {e.content.split('\n')[0] || 'Untitled'}
+              </button>
+              <Button size="sm" variant="ghost" onClick={() => handleDelete(e.id!)}>
+                Delete
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="flex-1">
+        {current && (
+          <JournalEditor
+            initialContent={current.content}
+            onSave={handleSave}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default JournalStorageSample;

--- a/frontend/src/features/journal/components/__tests__/JournalStorageSample.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/JournalStorageSample.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import JournalStorageSample from '../JournalStorageSample';
+import { indexedDB } from 'fake-indexeddb';
+
+// @ts-expect-error global assignment for test env
+global.indexedDB = indexedDB;
+
+describe('JournalStorageSample', () => {
+  beforeEach(() => {
+    const req = indexedDB.deleteDatabase('journal-db');
+    req.onsuccess = () => {};
+  });
+
+  it('creates a new entry and displays it', async () => {
+    const user = userEvent.setup();
+    render(<JournalStorageSample />);
+    await user.click(screen.getByRole('button', { name: /new entry/i }));
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, '# My Entry');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(await screen.findByText('My Entry')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/journal/hooks/useJournalStorage.ts
+++ b/frontend/src/features/journal/hooks/useJournalStorage.ts
@@ -1,0 +1,66 @@
+export interface JournalEntry {
+  id?: number;
+  content: string;
+}
+
+const DB_NAME = 'journal-db';
+const STORE_NAME = 'entries';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getAllEntries(): Promise<JournalEntry[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result as JournalEntry[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function addEntry(content: string): Promise<JournalEntry> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.add({ content });
+    req.onsuccess = () => resolve({ id: req.result as number, content });
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function updateEntry(entry: JournalEntry): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.put(entry);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function deleteEntry(id: number): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.delete(id);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/frontend/src/features/journal/index.ts
+++ b/frontend/src/features/journal/index.ts
@@ -1,3 +1,4 @@
 export { default as JournalEditor } from './components/JournalEditor';
 export { default as JournalEditorWithSections } from './components/JournalEditorWithSections';
+export { default as JournalStorageSample } from './components/JournalStorageSample';
 export type { JournalTemplate } from './components/JournalEditorWithSections';

--- a/frontend/src/pages/ComponentShowcase.tsx
+++ b/frontend/src/pages/ComponentShowcase.tsx
@@ -20,7 +20,7 @@ import type {
   GoalPattern,
 } from '../features/goals';
 
-import { JournalEditor } from '../features/journal';
+import { JournalEditor, JournalStorageSample } from '../features/journal';
 
 // Mock data for demonstrations
 const mockGoals: Goal[] = [
@@ -400,6 +400,11 @@ export const ComponentShowcase: React.FC = () => {
                   <h4 className="font-semibold text-gray-700 mb-2">Saved Markdown</h4>
                   <pre className="p-2 bg-gray-100 rounded border text-sm whitespace-pre-wrap">{journalContent}</pre>
                 </div>
+              </div>
+
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Journal Storage Sample</h3>
+                <JournalStorageSample />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- implement IndexedDB helpers for journal entries
- add `JournalStorageSample` component using IndexedDB
- showcase new sample in `ComponentShowcase`
- export new component from journal feature
- test saving a journal entry with fake-indexeddb
- include `fake-indexeddb` dev dependency

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687008e3187c8328b0efd3989314d503