### PR TITLE
Fix journal components type imports

### DIFF
--- a/frontend/src/features/journal/components/EditorSection.tsx
+++ b/frontend/src/features/journal/components/EditorSection.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
+import type { Editor } from '@tiptap/react';
+import type { Transaction } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from 'tiptap-markdown';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -70,12 +72,13 @@ const EditorSection: React.FC<EditorSectionProps> = ({
 
   useEffect(() => {
     if (!editor) return;
-    const unsubscribe = editor.on('update', () => {
-      const markdown = (editor.storage.markdown as { getMarkdown: () => string }).getMarkdown();
+    const handleUpdate = ({ editor: updatedEditor }: { editor: Editor; transaction: Transaction }) => {
+      const markdown = (updatedEditor.storage.markdown as { getMarkdown: () => string }).getMarkdown();
       onChange?.(markdown);
-    });
+    };
+    editor.on('update', handleUpdate);
     return () => {
-      editor.off('update', unsubscribe);
+      editor.off('update', handleUpdate);
     };
   }, [editor, onChange]);
 
@@ -170,4 +173,3 @@ const EditorSection: React.FC<EditorSectionProps> = ({
 };
 
 export default EditorSection;
-export type { EditorSectionProps };

--- a/frontend/src/features/journal/components/JournalEditorWithSections.tsx
+++ b/frontend/src/features/journal/components/JournalEditorWithSections.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/common';
-import EditorSection, { SectionDefinition } from './EditorSection';
+import EditorSection from './EditorSection';
+import type { SectionDefinition } from './EditorSection';
 
 export interface JournalTemplate {
   id: string;

--- a/frontend/src/features/journal/components/JournalStorageSample.tsx
+++ b/frontend/src/features/journal/components/JournalStorageSample.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import JournalEditor from './JournalEditor';
-import { JournalEntry, getAllEntries, addEntry, updateEntry, deleteEntry } from '../hooks/useJournalStorage';
+import type { JournalEntry } from '../hooks/useJournalStorage';
+import { getAllEntries, addEntry, updateEntry, deleteEntry } from '../hooks/useJournalStorage';
 import { Button } from '@/components/common';
 
 const JournalStorageSample: React.FC = () => {

--- a/frontend/src/features/journal/components/__tests__/JournalEditorWithSections.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/JournalEditorWithSections.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import JournalEditorWithSections, { JournalTemplate } from '../JournalEditorWithSections';
+import JournalEditorWithSections from '../JournalEditorWithSections';
+import type { JournalTemplate } from '../JournalEditorWithSections';
 
 const template: JournalTemplate = {
   id: 'daily',

--- a/frontend/src/features/journal/components/__tests__/JournalStorageSample.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/JournalStorageSample.test.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import JournalStorageSample from '../JournalStorageSample';
 import { indexedDB } from 'fake-indexeddb';
 
-// @ts-expect-error global assignment for test env
-global.indexedDB = indexedDB;
+// assigning indexedDB to global for test environment
+global.indexedDB = indexedDB as unknown as IDBFactory;
 
 describe('JournalStorageSample', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- adjust tiptap update listener in `EditorSection`
- import types using `import type`
- remove unused ts-expect-error in tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687010a3390c8328a6dccf20be2eb6be