### PR TITLE
Add journal template picker

### DIFF
--- a/frontend/src/features/journal/components/JournalTemplateDemo.tsx
+++ b/frontend/src/features/journal/components/JournalTemplateDemo.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import TemplatePicker from './TemplatePicker';
+import JournalEditor from './JournalEditor';
+import JournalEditorWithSections from './JournalEditorWithSections';
+import type { JournalTemplate } from './JournalEditorWithSections';
+
+const JournalTemplateDemo: React.FC = () => {
+  const [template, setTemplate] = useState<JournalTemplate | null>(null);
+  return (
+    <div className="space-y-4">
+      {!template && (
+        <TemplatePicker onSelect={setTemplate} />
+      )}
+      {template === null && (
+        <JournalEditor initialContent="" onSave={() => {}} />
+      )}
+      {template && (
+        <JournalEditorWithSections template={template} onSave={() => {}} />
+      )}
+    </div>
+  );
+};
+
+export default JournalTemplateDemo;

--- a/frontend/src/features/journal/components/TemplatePicker/TemplatePicker.tsx
+++ b/frontend/src/features/journal/components/TemplatePicker/TemplatePicker.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { JournalTemplate } from '../JournalEditorWithSections';
+import { useTemplateRegistry } from '../../hooks/useTemplateRegistry';
+
+interface TemplatePickerProps {
+  onSelect: (template: JournalTemplate | null) => void;
+}
+
+const TemplatePicker: React.FC<TemplatePickerProps> = ({ onSelect }) => {
+  const templates = useTemplateRegistry();
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        className="border rounded p-2 w-full text-left hover:bg-gray-50"
+        onClick={() => onSelect(null)}
+      >
+        Start from Scratch
+      </button>
+      {templates.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          className="border rounded p-2 w-full text-left hover:bg-gray-50"
+          onClick={() => onSelect(t)}
+        >
+          <div className="font-semibold">{t.name}</div>
+          <div className="text-sm text-gray-500">{t.description}</div>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default TemplatePicker;

--- a/frontend/src/features/journal/components/TemplatePicker/index.ts
+++ b/frontend/src/features/journal/components/TemplatePicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TemplatePicker';

--- a/frontend/src/features/journal/components/__tests__/TemplatePicker.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/TemplatePicker.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TemplatePicker from '../TemplatePicker';
+import { JournalTemplate } from '../JournalEditorWithSections';
+
+vi.mock('../../hooks/useTemplateRegistry', () => ({
+  useTemplateRegistry: () => [
+    {
+      id: 't1',
+      name: 'Template 1',
+      description: 'Desc',
+      sections: [],
+    } as JournalTemplate,
+  ],
+}));
+
+describe('TemplatePicker', () => {
+  it('calls onSelect when template clicked', async () => {
+    const user = userEvent.setup();
+    const handle = vi.fn();
+    render(<TemplatePicker onSelect={handle} />);
+    await user.click(screen.getByText('Template 1'));
+    expect(handle).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/journal/hooks/useTemplateRegistry.ts
+++ b/frontend/src/features/journal/hooks/useTemplateRegistry.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import type { JournalTemplate } from '../components/JournalEditorWithSections';
+
+export function useTemplateRegistry() {
+  const [templates, setTemplates] = useState<JournalTemplate[]>([]);
+
+  useEffect(() => {
+    const modules = import.meta.glob('../templates/*.json', { as: 'json' });
+    Promise.all(
+      Object.values(modules).map((load) => load() as Promise<JournalTemplate>)
+    ).then(setTemplates);
+  }, []);
+
+  return templates;
+}

--- a/frontend/src/features/journal/index.ts
+++ b/frontend/src/features/journal/index.ts
@@ -1,4 +1,6 @@
 export { default as JournalEditor } from './components/JournalEditor';
 export { default as JournalEditorWithSections } from './components/JournalEditorWithSections';
 export { default as JournalStorageSample } from './components/JournalStorageSample';
+export { default as JournalTemplateDemo } from './components/JournalTemplateDemo';
+export { default as TemplatePicker } from './components/TemplatePicker';
 export type { JournalTemplate } from './components/JournalEditorWithSections';

--- a/frontend/src/features/journal/templates/daily_log.json
+++ b/frontend/src/features/journal/templates/daily_log.json
@@ -1,0 +1,20 @@
+{
+  "id": "daily_log",
+  "name": "Daily Log",
+  "description": "Quick notes about your day.",
+  "version": 1,
+  "sections": [
+    {
+      "id": "summary",
+      "title": "Summary",
+      "type": "paragraph",
+      "placeholder": "What happened today?"
+    },
+    {
+      "id": "mood",
+      "title": "Mood",
+      "type": "paragraph",
+      "placeholder": "How did you feel overall?"
+    }
+  ]
+}

--- a/frontend/src/features/journal/templates/gratitude_daily.json
+++ b/frontend/src/features/journal/templates/gratitude_daily.json
@@ -1,0 +1,20 @@
+{
+  "id": "gratitude_daily",
+  "name": "Daily Gratitude",
+  "description": "List three things you're grateful for and reflect on why.",
+  "version": 1,
+  "sections": [
+    {
+      "id": "gratitude_list",
+      "title": "Things I'm grateful for",
+      "type": "paragraph",
+      "placeholder": "Write at least three items…"
+    },
+    {
+      "id": "reflection",
+      "title": "Why they matter",
+      "type": "paragraph",
+      "placeholder": "Reflect on the meaning behind your gratitude items…"
+    }
+  ]
+}

--- a/frontend/src/pages/ComponentShowcase.tsx
+++ b/frontend/src/pages/ComponentShowcase.tsx
@@ -20,7 +20,11 @@ import type {
   GoalPattern,
 } from '../features/goals';
 
-import { JournalEditor, JournalStorageSample } from '../features/journal';
+import {
+  JournalEditor,
+  JournalStorageSample,
+  JournalTemplateDemo,
+} from '../features/journal';
 
 // Mock data for demonstrations
 const mockGoals: Goal[] = [
@@ -405,6 +409,11 @@ export const ComponentShowcase: React.FC = () => {
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Journal Storage Sample</h3>
                 <JournalStorageSample />
+              </div>
+
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Template Picker Demo</h3>
+                <JournalTemplateDemo />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- enable editing journal entries from template JSON files
- add template registry hook with Vite glob loading
- provide TemplatePicker and demo component
- wire demo into ComponentShowcase
- test TemplatePicker behaviour

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test -- -t TemplatePicker`
- `make lint` *(fails: module not installed)*
- `make test` *(fails: ModuleNotFoundError, NoRegionError)*

------
https://chatgpt.com/codex/tasks/task_e_687032f4a86883289931e5f8496462b6