### PR TITLE
Fix journal template type errors

### DIFF
--- a/frontend/src/features/journal/components/__tests__/JournalEditorWithSections.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/JournalEditorWithSections.test.tsx
@@ -7,6 +7,7 @@ import type { JournalTemplate } from '../../types/template.types';
 const template: JournalTemplate = {
   id: 'daily',
   name: 'Daily',
+  version: 1,
   sections: [
     { id: 'feelings', title: 'Feelings', prompt: 'How do you feel?' },
     { id: 'thoughts', title: 'Thoughts', prompt: 'What are you thinking?' },

--- a/frontend/src/features/journal/components/__tests__/TemplatePicker.test.tsx
+++ b/frontend/src/features/journal/components/__tests__/TemplatePicker.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TemplatePicker from '../TemplatePicker';
-import { JournalTemplate } from '../../types/template.types';
+import type { JournalTemplate } from '../../types/template.types';
 
 vi.mock('../../hooks/useTemplateRegistry', () => ({
   useTemplateRegistry: () => ({
@@ -11,6 +11,7 @@ vi.mock('../../hooks/useTemplateRegistry', () => ({
         id: 't1',
         name: 'Template 1',
         description: 'Desc',
+        version: 1,
         sections: [],
       } as JournalTemplate,
     ],

--- a/frontend/src/features/journal/hooks/__tests__/useTemplateRegistry.test.tsx
+++ b/frontend/src/features/journal/hooks/__tests__/useTemplateRegistry.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useTemplateRegistry } from '../useTemplateRegistry';
 
@@ -14,7 +14,7 @@ describe('useTemplateRegistry', () => {
   });
 
   it('skips invalid templates', async () => {
-    const fetchMock = global.fetch as unknown as vi.Mock;
+    const fetchMock = global.fetch as unknown as Mock;
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ['/bad.json'] });
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ foo: 'bar' }) });
 
@@ -25,7 +25,7 @@ describe('useTemplateRegistry', () => {
   });
 
   it('skips template with invalid privacy', async () => {
-    const fetchMock = global.fetch as unknown as vi.Mock;
+    const fetchMock = global.fetch as unknown as Mock;
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ['/bad.json'] });
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -46,7 +46,7 @@ describe('useTemplateRegistry', () => {
   });
 
   it('migrates template when version differs', async () => {
-    const fetchMock = global.fetch as unknown as vi.Mock;
+    const fetchMock = global.fetch as unknown as Mock;
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ['/v2.json'] });
     fetchMock.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary
- add missing `version` field in journal test templates
- use type-only import for `JournalTemplate`
- update `useTemplateRegistry` tests for Vitest globals
- refactor `useTemplateRegistry` to map raw templates and apply migrations

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6870519b24f8832890fa0b96a65449ca