### PR TITLE
Add mock AI client and context

### DIFF
--- a/frontend/src/services/ai/HttpAiClient.ts
+++ b/frontend/src/services/ai/HttpAiClient.ts
@@ -1,0 +1,8 @@
+import type { AiClient } from './types';
+import apiClient from '../../api/client';
+
+export const HttpAiClient: AiClient = {
+  reflect: (body) => apiClient.post('/ai/reflect', body).then(r => r.data),
+  analyzeMood: (body) => apiClient.post('/ai/analyze-mood', body).then(r => r.data),
+  summarizeWeek: (body) => apiClient.post('/ai/summarize-week', body).then(r => r.data),
+};

--- a/frontend/src/services/ai/MockAiClient.ts
+++ b/frontend/src/services/ai/MockAiClient.ts
@@ -1,0 +1,29 @@
+import type { AiClient } from './types';
+
+function delay(ms = 600) {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+export const MockAiClient: AiClient = {
+  async reflect({ text, prompt }) {
+    await delay();
+    return {
+      reply: `🤖 MOCK: Based on "${text.slice(0, 40)}...", here's a reflective Q:\n${prompt.replace(/Suggest|Which|Describe/i, 'In your opinion,')}`,
+    };
+  },
+
+  async analyzeMood() {
+    await delay();
+    return {
+      emotions: { joy: 0.4, sadness: 0.1, anger: 0.05, fear: 0.05, neutral: 0.4 },
+    };
+  },
+
+  async summarizeWeek({ entries }) {
+    await delay(800);
+    return {
+      summary: `🤖 MOCK: You wrote ${entries.length} entries. Keep it up!`,
+      highlights: ['Consistency ✅', 'Mood trending positive 📈'],
+    };
+  },
+};

--- a/frontend/src/services/ai/__tests__/MockAiClient.test.ts
+++ b/frontend/src/services/ai/__tests__/MockAiClient.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { MockAiClient } from '../MockAiClient';
+
+describe('MockAiClient', () => {
+  it('generates reflection response', async () => {
+    const res = await MockAiClient.reflect({
+      entryId: 'e1',
+      sectionId: 's1',
+      text: 'I am thankful for my friends and family',
+      prompt: 'Suggest a reflection question',
+    });
+    expect(res.reply).toContain('🤖 MOCK');
+  });
+});

--- a/frontend/src/services/ai/index.ts
+++ b/frontend/src/services/ai/index.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+import { HttpAiClient } from './HttpAiClient';
+import { MockAiClient } from './MockAiClient';
+import type { AiClient } from './types';
+
+const client: AiClient =
+  import.meta.env.VITE_USE_AI_MOCK === 'true' ? MockAiClient : HttpAiClient;
+
+const AiContext = createContext<AiClient>(client);
+export const AiProvider = AiContext.Provider;
+export const useAi = () => useContext(AiContext);

--- a/frontend/src/services/ai/types.ts
+++ b/frontend/src/services/ai/types.ts
@@ -1,0 +1,21 @@
+export interface AiClient {
+  /** Section-level reflection (prompted by section.aiPrompt) */
+  reflect(input: {
+    entryId: string;
+    sectionId: string;
+    text: string;
+    prompt: string;
+  }): Promise<{ reply: string }>;
+
+  /** Entry-level mood / sentiment classification */
+  analyzeMood(input: {
+    entryId: string;
+    markdown: string;
+  }): Promise<{ emotions: Record<string, number> }>;
+
+  /** Weekly digest summary */
+  summarizeWeek(input: {
+    userId: string;
+    entries: { id: string; markdown: string }[];
+  }): Promise<{ summary: string; highlights: string[] }>;
+}


### PR DESCRIPTION
## Summary
- add AiClient interface
- add HttpAiClient placeholder
- implement MockAiClient
- create AiContext provider and hook
- add tests for MockAiClient

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6870598585cc832888ed266f11b9e77e