### PR TITLE
Add global theme picker

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { store } from './store';
 // import { ReactQueryDevtools } from '@tanstack/react-query-devtools'; // Commented out for React 19 compatibility
 
 // Context
-import { AuthProvider } from './contexts';
+import { AuthProvider, ThemeProvider } from './contexts';
 
 // Layouts
 import PublicLayout from './components/layout/PublicLayout';
@@ -52,6 +52,7 @@ function App() {
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
         <Router>
+          <ThemeProvider>
           <AuthProvider>
           <Routes>
             {/* Public Routes */}
@@ -96,6 +97,7 @@ function App() {
           <SessionWarning />
           <DevTools />
           </AuthProvider>
+          </ThemeProvider>
         </Router>
         {/* <ReactQueryDevtools initialIsOpen={false} /> */}
       </QueryClientProvider>

--- a/frontend/src/components/common/ThemePicker.tsx
+++ b/frontend/src/components/common/ThemePicker.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTheme, Theme } from '../../contexts';
+
+const options: { label: string; value: Theme }[] = [
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Reading', value: 'reading' },
+];
+
+const ThemePicker: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value as Theme)}
+      className="border-gray-300 rounded-md text-sm"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default ThemePicker;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -6,3 +6,4 @@ export type { InputProps } from './Input';
 
 export { default as DevTools } from './DevTools';
 export { default as LoadingScreen } from './LoadingScreen';
+export { default as ThemePicker } from './ThemePicker';

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -7,9 +7,9 @@ const AppLayout: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Header 
-        onMobileMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)} 
+    <div className="min-h-screen bg-surface text-theme">
+      <Header
+        onMobileMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
       />
       
       <MobileMenu 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts';
+import { ThemePicker } from '../common';
 
 interface HeaderProps {
   onMobileMenuToggle: () => void;
@@ -35,7 +36,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
   };
 
   return (
-    <header className="bg-white shadow">
+    <header className="bg-surface shadow">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo and Desktop Navigation */}
@@ -140,7 +141,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
 
               {/* Dropdown Menu */}
               {isUserMenuOpen && (
-                <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+                <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
                   <div className="py-1" role="menu" aria-orientation="vertical">
                     <div className="px-4 py-2 text-sm text-gray-700 border-b">
                       <div className="font-medium">{user?.firstName} {user?.lastName}</div>
@@ -162,6 +163,9 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
                     >
                       Settings
                     </Link>
+                    <div className="px-4 py-2">
+                      <ThemePicker />
+                    </div>
                     <button
                       onClick={handleLogout}
                       className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/frontend/src/components/layout/MobileMenu.tsx
+++ b/frontend/src/components/layout/MobileMenu.tsx
@@ -26,7 +26,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
       />
 
       {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 max-w-xs w-full bg-white shadow-xl z-50 md:hidden">
+      <div className="fixed inset-y-0 right-0 max-w-xs w-full bg-surface shadow-xl z-50 md:hidden">
         <div className="flex items-center justify-between p-4 border-b">
           <div>
             <div className="text-base font-medium text-gray-900">

--- a/frontend/src/components/layout/PublicLayout.tsx
+++ b/frontend/src/components/layout/PublicLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const PublicLayout: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-surface text-theme">
       <Outlet />
     </div>
   );

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { ThemeContext, Theme } from './ThemeContextType';
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+const THEME_KEY = 'theme-preference';
+const themes: Theme[] = ['light', 'dark', 'reading'];
+
+const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(THEME_KEY) as Theme | null;
+    if (stored && themes.includes(stored)) {
+      setThemeState(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.remove('theme-light', 'theme-dark', 'theme-reading');
+    document.body.classList.add(`theme-${theme}`);
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+
+  const setTheme = (newTheme: Theme) => {
+    if (themes.includes(newTheme)) {
+      setThemeState(newTheme);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/frontend/src/contexts/ThemeContextType.ts
+++ b/frontend/src/contexts/ThemeContextType.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export type Theme = 'light' | 'dark' | 'reading';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -1,3 +1,6 @@
 export { useAuth } from './useAuth';
 export { default as AuthProvider } from './AuthContext';
 export type { AuthContextValue } from './AuthContextType';
+export { useTheme } from './useTheme';
+export { default as ThemeProvider } from './ThemeContext';
+export type { Theme, ThemeContextValue } from './ThemeContextType';

--- a/frontend/src/contexts/useTheme.ts
+++ b/frontend/src/contexts/useTheme.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from './ThemeContextType';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,8 +8,27 @@
   }
 
   body {
-    @apply bg-white text-gray-900;
     font-feature-settings: "rlig" 1, "calt" 1;
+    background-color: var(--color-background);
+    color: var(--color-text);
+  }
+
+  body.theme-light {
+    --color-background: #f9fafb; /* gray-50 */
+    --color-surface: #ffffff;
+    --color-text: #111827; /* gray-900 */
+  }
+
+  body.theme-dark {
+    --color-background: #1f2937; /* gray-800 */
+    --color-surface: #111827; /* gray-900 */
+    --color-text: #f3f4f6; /* gray-100 */
+  }
+
+  body.theme-reading {
+    --color-background: #f5f1e6;
+    --color-surface: #fdf8e3;
+    --color-text: #433418;
   }
 }
 
@@ -69,6 +88,14 @@
     );
     background-size: 1000% 100%;
     animation: shimmer 2s infinite linear;
+  }
+
+  .bg-surface {
+    background-color: var(--color-surface);
+  }
+
+  .text-theme {
+    color: var(--color-text);
   }
   
   @keyframes shimmer {


### PR DESCRIPTION
## Summary
- add Theme context and provider with light, dark and reading modes
- implement ThemePicker dropdown in header
- update layouts to use theme classes
- style themes via CSS variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm run test` *(fails: vitest not found)*
- `make lint` *(fails: terraform modules not installed)*
- `make test` *(fails: botocore.exceptions.NoRegionError)*

------
https://chatgpt.com/codex/tasks/task_e_68706bd186ec8328b716781aa2f72fab