### PR TITLE
Add Wellness Dashboard page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { ComponentShowcase } from './pages/ComponentShowcase';
 import GoalsPage from './pages/goals/GoalsPage';
 import CreateGoalPage from './pages/goals/CreateGoalPage';
 import GoalDetailPage from './pages/goals/GoalDetailPage';
+import GoalsDashboardPage from './pages/goals/GoalsDashboardPage';
 
 // Components
 import DevTools from './components/common/DevTools';
@@ -85,7 +86,7 @@ function App() {
               
               <Route path="/meals" element={<div>Meals - Coming Soon</div>} />
               <Route path="/workouts" element={<div>Workouts - Coming Soon</div>} />
-              <Route path="/wellness" element={<div>Wellness - Coming Soon</div>} />
+              <Route path="/wellness" element={<GoalsDashboardPage />} />
             </Route>
 
             {/* Default redirect */}

--- a/frontend/src/features/goals/components/display/GoalsSummaryHeader.tsx
+++ b/frontend/src/features/goals/components/display/GoalsSummaryHeader.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { Goal } from '../../types/api.types';
+
+interface GoalsSummaryHeaderProps {
+  goals: Goal[];
+}
+
+const GoalsSummaryHeader: React.FC<GoalsSummaryHeaderProps> = ({ goals }) => {
+  const activeCount = goals.length;
+  const longestStreak = goals.reduce(
+    (max, g) => Math.max(max, g.progress.currentStreak || 0),
+    0
+  );
+  const avgSuccess =
+    activeCount > 0
+      ? Math.round(
+          goals.reduce((sum, g) => sum + g.progress.successRate, 0) / activeCount
+        )
+      : 0;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+        <div className="text-2xl font-bold text-gray-900">{activeCount}</div>
+        <p className="text-sm text-gray-600">Active Goals</p>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+        <div className="flex items-center justify-center text-2xl font-bold text-orange-600 gap-1">
+          <span>{longestStreak}</span>
+          <span>🔥</span>
+        </div>
+        <p className="text-sm text-gray-600">Current Streak</p>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+        <div className="text-2xl font-bold text-primary-600">{avgSuccess}%</div>
+        <p className="text-sm text-gray-600">Avg Success</p>
+      </div>
+    </div>
+  );
+};
+
+export default GoalsSummaryHeader;

--- a/frontend/src/pages/goals/GoalsDashboardPage.tsx
+++ b/frontend/src/pages/goals/GoalsDashboardPage.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GoalList from '../../features/goals/components/display/GoalList';
+import GoalsSummaryHeader from '../../features/goals/components/display/GoalsSummaryHeader';
+import { useGoals } from '../../features/goals/hooks/useGoals';
+import QuickLogModal from '../../features/goals/components/logging/QuickLogModal';
+import type { Goal } from '../../features/goals/types/api.types';
+
+const GoalsDashboardPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { data, isLoading } = useGoals({ status: ['active'] });
+  const [quickLogGoalId, setQuickLogGoalId] = useState<string | null>(null);
+
+  const handleQuickLog = (goalId: string) => {
+    const goal: Goal | undefined = data?.goals.find((g) => g.goalId === goalId);
+    const maybeType = goal as unknown as { goalType?: string } | undefined;
+    if (maybeType?.goalType === 'journal') {
+      navigate('/journal');
+      return;
+    }
+    setQuickLogGoalId(goalId);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <h1 className="text-3xl font-bold text-gray-900">Wellness Dashboard</h1>
+        <GoalsSummaryHeader goals={data?.goals || []} />
+        <GoalList goals={data?.goals || []} isLoading={isLoading} onQuickLog={handleQuickLog} />
+      </div>
+      {quickLogGoalId && (
+        <QuickLogModal
+          goalId={quickLogGoalId}
+          isOpen={!!quickLogGoalId}
+          onClose={() => setQuickLogGoalId(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default GoalsDashboardPage;


### PR DESCRIPTION
## Summary
- implement `GoalsDashboardPage` for viewing active goals
- add `GoalsSummaryHeader` component
- hook up `/wellness` route to new dashboard page

## Testing
- `npm run lint`
- `npm run test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_687073fe4f48832884fa0ec83ea0dd10