### PR TITLE
feat(theme): picker ui, palette tuning, final polish

### DIFF
--- a/docs/theme-restart-assessment-2025-07-11.md
+++ b/docs/theme-restart-assessment-2025-07-11.md
@@ -1,0 +1,24 @@
+# Theme Restart Assessment - 2025-07-11
+
+```
+$ git status --short
+```
+```
+?? docs/theme-restart-assessment-2025-07-11.md
+```
+
+```
+$ grep -R "<ThemeProvider" frontend/src | head -10
+```
+```
+frontend/src/App.tsx:      <ThemeProvider>
+frontend/src/components/common/__tests__/ThemeProvider.test.tsx:    <ThemeProvider>
+frontend/src/contexts/ThemeContext.tsx:const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+```
+
+```
+$ grep -R "bg-white" frontend/src/features | wc -l
+```
+```
+49
+```

--- a/docs/theme-sweep-2025-07-11.md
+++ b/docs/theme-sweep-2025-07-11.md
@@ -1,0 +1,11 @@
+# Theme Sweep - 2025-07-11
+
+```
+$ git status --short
+?? docs/theme-sweep-2025-07-11.md
+```
+
+```
+$ grep -R "bg-white" frontend/src | wc -l
+19
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script>
+      (function () {
+        const stored = localStorage.getItem('theme-preference');
+        const theme = stored || 'dark';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { store } from './store';
 // import { ReactQueryDevtools } from '@tanstack/react-query-devtools'; // Commented out for React 19 compatibility
 
 // Context
-import { AuthProvider } from './contexts';
+import { AuthProvider, ThemeProvider, useTheme, Theme } from './contexts';
 
 // Layouts
 import PublicLayout from './components/layout/PublicLayout';
@@ -20,6 +20,7 @@ import LoginPage from './pages/auth/LoginPage';
 // Pages - App
 import DashboardPage from './pages/DashboardPage';
 import { ComponentShowcase } from './pages/ComponentShowcase';
+import SettingsPage from './pages/SettingsPage';
 
 // Pages - Goals
 import GoalsPage from './pages/goals/GoalsPage';
@@ -29,6 +30,8 @@ import GoalDetailPage from './pages/goals/GoalDetailPage';
 // Components
 import DevTools from './components/common/DevTools';
 import { SessionWarning } from './components/SessionWarning';
+
+const cycleOrder: Theme[] = ['dark', 'light', 'reading'];
 
 // Create a client
 const queryClient = new QueryClient({
@@ -48,10 +51,18 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  const { theme, setTheme } = useTheme();
+  const cycleTheme = () => {
+    const index = cycleOrder.indexOf(theme);
+    const next = cycleOrder[(index + 1) % cycleOrder.length];
+    setTheme(next);
+  };
+
   return (
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
-        <Router>
+        <ThemeProvider>
+          <Router>
           <AuthProvider>
           <Routes>
             {/* Public Routes */}
@@ -75,7 +86,7 @@ function App() {
               <Route path="/dashboard" element={<DashboardPage />} />
               <Route path="/showcase" element={<ComponentShowcase />} />
               <Route path="/profile" element={<div>Profile - Coming Soon</div>} />
-              <Route path="/settings" element={<div>Settings - Coming Soon</div>} />
+              <Route path="/settings" element={<SettingsPage />} />
               <Route path="/settings/security" element={<div>Security Settings - Coming Soon</div>} />
               
               {/* Goals Routes */}
@@ -95,10 +106,18 @@ function App() {
           {/* Global Components */}
           <SessionWarning />
           <DevTools />
+          <button
+            type="button"
+            onClick={cycleTheme}
+            className="fixed bottom-2 right-2 px-3 py-1 rounded bg-accent text-white"
+          >
+            Theme: {theme}
+          </button>
           </AuthProvider>
-        </Router>
-        {/* <ReactQueryDevtools initialIsOpen={false} /> */}
+          </Router>
+        </ThemeProvider>
       </QueryClientProvider>
+    {/* <ReactQueryDevtools initialIsOpen={false} /> */}
     </Provider>
   );
 }

--- a/frontend/src/components/SessionWarning.tsx
+++ b/frontend/src/components/SessionWarning.tsx
@@ -34,9 +34,9 @@ export const SessionWarning: React.FC = () => {
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex min-h-full items-center justify-center p-4 text-center">
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick={dismissSessionWarning} />
+        <div className="fixed inset-0 bg-black/60 transition-opacity" onClick={dismissSessionWarning} />
         
-        <div className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
+        <div className="relative transform overflow-hidden rounded-lg bg-[var(--surface)] px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
           <div>
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100">
               <svg
@@ -55,13 +55,13 @@ export const SessionWarning: React.FC = () => {
             </div>
             
             <div className="mt-3 text-center sm:mt-5">
-              <h3 className="text-base font-semibold leading-6 text-gray-900">
+              <h3 className="text-base font-semibold leading-6 text-[var(--text)]">
                 Session Expiring Soon
               </h3>
               <div className="mt-2">
                 <p className="text-sm text-gray-500">
                   Your session will expire in{' '}
-                  <span className="font-semibold text-gray-900">{timeRemaining}</span>.
+                  <span className="font-semibold text-[var(--text)]">{timeRemaining}</span>.
                   Would you like to continue working?
                 </p>
               </div>
@@ -80,7 +80,7 @@ export const SessionWarning: React.FC = () => {
               type="button"
               variant="secondary"
               onClick={() => logout('manual')}
-              className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
+              className="mt-3 inline-flex w-full justify-center rounded-md bg-[var(--surface)] px-3 py-2 text-sm font-semibold text-[var(--text)] shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-[color:var(--surface-muted)] sm:col-start-1 sm:mt-0"
             >
               Log Out
             </Button>

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -29,13 +29,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
-    const baseStyles = 'inline-flex items-center justify-center font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+    const baseStyles = 'inline-flex items-center justify-center font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] disabled:opacity-50 disabled:cursor-not-allowed';
 
     const variants = {
       primary: 'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500',
       secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500',
-      outline: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:ring-primary-500',
-      ghost: 'text-gray-700 hover:bg-gray-100 focus:ring-gray-500',
+      outline: 'border border-[color:var(--surface-muted)] bg-[var(--surface)] text-gray-700 hover:bg-[color:var(--surface-muted)] focus:ring-primary-500',
+      ghost: 'text-gray-700 hover:bg-[color:var(--surface-muted)] focus:ring-gray-500',
       danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
     };
 

--- a/frontend/src/components/common/DevTools.tsx
+++ b/frontend/src/components/common/DevTools.tsx
@@ -84,12 +84,12 @@ const DevTools: React.FC = () => {
 
       {/* Dev Tools Panel */}
       {isOpen && (
-        <div className="fixed bottom-20 right-4 bg-white rounded-lg shadow-xl p-4 w-96 max-h-[600px] overflow-y-auto z-50 border border-gray-200">
+        <div className="fixed bottom-20 right-4 bg-[var(--surface)] rounded-lg shadow-xl p-4 w-96 max-h-[600px] overflow-y-auto z-50 border border-[color:var(--surface-muted)]">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">Dev Tools</h3>
+            <h3 className="text-lg font-semibold text-[var(--text)]">Dev Tools</h3>
             <button
               onClick={() => setIsOpen(false)}
-              className="text-gray-400 hover:text-gray-600"
+              className="text-gray-400 hover:text-muted"
             >
               <svg
                 className="w-5 h-5"
@@ -109,7 +109,7 @@ const DevTools: React.FC = () => {
           </div>
 
           {/* MSW Status */}
-          <div className="mb-4 p-3 bg-gray-50 rounded">
+          <div className="mb-4 p-3 bg-[var(--surface-muted)] rounded">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-gray-700">MSW Status:</span>
               <span
@@ -168,7 +168,7 @@ const DevTools: React.FC = () => {
                     <span className="text-gray-500">MFA Enabled:</span>{' '}
                     <span
                       className={`font-medium ${
-                        user.mfaEnabled ? 'text-green-600' : 'text-gray-600'
+                        user.mfaEnabled ? 'text-green-600' : 'text-muted'
                       }`}
                     >
                       {user.mfaEnabled ? 'Yes' : 'No'}
@@ -185,9 +185,9 @@ const DevTools: React.FC = () => {
               <h4 className="text-sm font-medium text-gray-700 mb-2">Tokens</h4>
               <div className="space-y-2">
                 {/* Access Token */}
-                <div className="p-2 bg-gray-50 rounded">
+                <div className="p-2 bg-[var(--surface-muted)] rounded">
                   <div className="flex justify-between items-center mb-1">
-                    <span className="text-xs font-medium text-gray-600">
+                    <span className="text-xs font-medium text-muted">
                       Access Token
                     </span>
                     <button
@@ -205,9 +205,9 @@ const DevTools: React.FC = () => {
                 </div>
 
                 {/* Refresh Token */}
-                <div className="p-2 bg-gray-50 rounded">
+                <div className="p-2 bg-[var(--surface-muted)] rounded">
                   <div className="flex justify-between items-center mb-1">
-                    <span className="text-xs font-medium text-gray-600">
+                    <span className="text-xs font-medium text-muted">
                       Refresh Token
                     </span>
                     <button
@@ -235,7 +235,7 @@ const DevTools: React.FC = () => {
             <div className="space-y-2">
               <button
                 onClick={() => window.location.reload()}
-                className="w-full text-left px-3 py-2 text-sm bg-gray-50 hover:bg-gray-100 rounded transition-colors"
+                className="w-full text-left px-3 py-2 text-sm bg-[var(--surface-muted)] hover:bg-[color:var(--surface-muted)] rounded transition-colors"
               >
                 🔄 Reload Page
               </button>
@@ -259,14 +259,14 @@ const DevTools: React.FC = () => {
                     sessionStorage: { ...sessionStorage },
                   });
                 }}
-                className="w-full text-left px-3 py-2 text-sm bg-gray-50 hover:bg-gray-100 rounded transition-colors"
+                className="w-full text-left px-3 py-2 text-sm bg-[var(--surface-muted)] hover:bg-[color:var(--surface-muted)] rounded transition-colors"
               >
                 📋 Log State to Console
               </button>
             </div>
           </div>
 
-          <div className="mt-4 pt-4 border-t border-gray-200">
+          <div className="mt-4 pt-4 border-t border-[color:var(--surface-muted)]">
             <p className="text-xs text-gray-500 text-center">
               Development Tools - {import.meta.env.MODE} mode
             </p>

--- a/frontend/src/components/common/Input.tsx
+++ b/frontend/src/components/common/Input.tsx
@@ -29,12 +29,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
 
     const inputClasses = clsx(
-      'block w-full rounded-md shadow-sm transition-colors sm:text-sm',
+      'block w-full rounded-md shadow-sm transition-colors sm:text-sm text-[var(--text)]',
       leftIcon && 'pl-10',
       rightIcon && 'pr-10',
       error
         ? 'border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500'
-        : 'border-gray-300 focus:border-primary-500 focus:ring-primary-500',
+        : 'border-[color:var(--surface-muted)] focus:border-primary-500 focus:ring-primary-500',
       className
     );
 

--- a/frontend/src/components/common/LoadingScreen.tsx
+++ b/frontend/src/components/common/LoadingScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const LoadingScreen: React.FC = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-[var(--surface-muted)]">
       <div className="text-center">
         <div className="inline-flex items-center justify-center w-16 h-16 mb-4">
           <svg
@@ -26,7 +26,7 @@ const LoadingScreen: React.FC = () => {
             />
           </svg>
         </div>
-        <h2 className="text-lg font-medium text-gray-900">Loading...</h2>
+        <h2 className="text-lg font-medium text-[var(--text)]">Loading...</h2>
         <p className="mt-1 text-sm text-gray-500">Please wait while we get things ready</p>
       </div>
     </div>

--- a/frontend/src/components/common/ThemeSwitcher.tsx
+++ b/frontend/src/components/common/ThemeSwitcher.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useTheme } from '../../contexts';
+import type { Theme } from '../../contexts';
+
+const options: { label: string; value: Theme }[] = [
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Reading', value: 'reading' },
+];
+
+const ThemeSwitcher: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value as Theme)}
+      className="border-[color:var(--surface-muted)] rounded-md text-sm"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default ThemeSwitcher;

--- a/frontend/src/components/common/__tests__/ThemeProvider.test.tsx
+++ b/frontend/src/components/common/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { test, expect } from 'vitest';
+import { ThemeProvider, useTheme } from '../../../contexts';
+
+test('toggles dark class on html element', async () => {
+  const TestComp = () => {
+    const { setTheme } = useTheme();
+    return <button onClick={() => setTheme('dark')}>switch</button>;
+  };
+
+  const user = userEvent.setup();
+  render(
+    <ThemeProvider>
+      <TestComp />
+    </ThemeProvider>
+  );
+
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  await user.click(screen.getByText('switch'));
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -6,3 +6,4 @@ export type { InputProps } from './Input';
 
 export { default as DevTools } from './DevTools';
 export { default as LoadingScreen } from './LoadingScreen';
+export { default as ThemeSwitcher } from './ThemeSwitcher';

--- a/frontend/src/components/debug/ApiDebugger.tsx
+++ b/frontend/src/components/debug/ApiDebugger.tsx
@@ -114,9 +114,9 @@ const ApiDebugger: React.FC = () => {
     <div className="p-6 max-w-4xl mx-auto">
       <h2 className="text-2xl font-bold mb-4">API Debugger</h2>
       
-      <div className="mb-4 p-4 bg-gray-100 rounded">
+      <div className="mb-4 p-4 bg-[var(--surface-muted)] rounded">
         <p className="font-semibold">API URL: {import.meta.env.VITE_API_URL || 'Not configured'}</p>
-        <p className="text-sm text-gray-600">Environment: {import.meta.env.VITE_ENVIRONMENT}</p>
+        <p className="text-sm text-muted">Environment: {import.meta.env.VITE_ENVIRONMENT}</p>
       </div>
 
       <div className="space-y-2 mb-6">

--- a/frontend/src/components/encryption/EncryptionIndicator.tsx
+++ b/frontend/src/components/encryption/EncryptionIndicator.tsx
@@ -25,7 +25,7 @@ const statusConfig = {
   unencrypted: {
     icon: Unlock,
     color: 'text-gray-400',
-    bgColor: 'bg-gray-100',
+    bgColor: 'bg-[var(--surface-muted)]',
     label: 'Not encrypted',
   },
   partial: {
@@ -99,7 +99,7 @@ export const EncryptionStatusList: React.FC<EncryptionStatusListProps> = ({
             key={module.moduleId}
             className="flex items-center justify-between py-1"
           >
-            <span className="text-sm text-gray-600">{module.moduleName}</span>
+            <span className="text-sm text-muted">{module.moduleName}</span>
             <EncryptionIndicator
               status={module.status}
               size="sm"

--- a/frontend/src/components/encryption/EncryptionOnboarding.tsx
+++ b/frontend/src/components/encryption/EncryptionOnboarding.tsx
@@ -76,7 +76,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
   const CurrentIcon = steps[currentStep].icon;
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="max-w-2xl w-full">
         {/* Progress bar */}
         <div className="mb-8">
@@ -113,7 +113,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
           </div>
           <div className="flex justify-between text-sm">
             {steps.map((step) => (
-              <span key={step.id} className="text-gray-600">
+              <span key={step.id} className="text-muted">
                 {step.title}
               </span>
             ))}
@@ -121,12 +121,12 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
         </div>
 
         {/* Content */}
-        <div className="bg-white rounded-lg shadow-lg p-8">
+        <div className="bg-[var(--surface)] rounded-lg shadow-lg p-8">
           <div className="text-center mb-8">
             <div className="mx-auto w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mb-4">
               <CurrentIcon className="h-8 w-8 text-purple-600" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            <h2 className="text-2xl font-bold text-[var(--text)] mb-2">
               {steps[currentStep].title}
             </h2>
           </div>
@@ -135,7 +135,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
           {currentStep === 0 && (
             <div className="space-y-6">
               <div className="text-center space-y-4">
-                <p className="text-gray-600">
+                <p className="text-muted">
                   Protect your personal data with end-to-end encryption.
                   Only you can decrypt your information.
                 </p>
@@ -144,22 +144,22 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
               <div className="grid gap-4 md:grid-cols-3">
                 <div className="bg-purple-50 rounded-lg p-4">
                   <Shield className="h-8 w-8 text-purple-600 mb-2" />
-                  <h3 className="font-semibold text-gray-900 mb-1">Private & Secure</h3>
-                  <p className="text-sm text-gray-600">
+                  <h3 className="font-semibold text-[var(--text)] mb-1">Private & Secure</h3>
+                  <p className="text-sm text-muted">
                     Your data is encrypted locally before storage
                   </p>
                 </div>
                 <div className="bg-purple-50 rounded-lg p-4">
                   <Lock className="h-8 w-8 text-purple-600 mb-2" />
-                  <h3 className="font-semibold text-gray-900 mb-1">You Control Access</h3>
-                  <p className="text-sm text-gray-600">
+                  <h3 className="font-semibold text-[var(--text)] mb-1">You Control Access</h3>
+                  <p className="text-sm text-muted">
                     Share specific data temporarily when needed
                   </p>
                 </div>
                 <div className="bg-purple-50 rounded-lg p-4">
                   <Key className="h-8 w-8 text-purple-600 mb-2" />
-                  <h3 className="font-semibold text-gray-900 mb-1">Backup Available</h3>
-                  <p className="text-sm text-gray-600">
+                  <h3 className="font-semibold text-[var(--text)] mb-1">Backup Available</h3>
+                  <p className="text-sm text-muted">
                     Secure key backup ensures you never lose access
                   </p>
                 </div>
@@ -170,24 +170,24 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
           {currentStep === 1 && (
             <div className="space-y-6">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">
                   Choose what to encrypt
                 </h3>
                 <div className="space-y-3">
                   {availableModules.map((module) => (
                     <label
                       key={module.id}
-                      className="flex items-start p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer"
+                      className="flex items-start p-4 border border-[color:var(--surface-muted)] rounded-lg hover:bg-[color:var(--surface-muted)] cursor-pointer"
                     >
                       <input
                         type="checkbox"
                         checked={settings.modules.includes(module.id)}
                         onChange={() => toggleModule(module.id)}
-                        className="h-5 w-5 text-purple-600 rounded border-gray-300 mt-0.5"
+                        className="h-5 w-5 text-purple-600 rounded border-[color:var(--surface-muted)] mt-0.5"
                       />
                       <div className="ml-3 flex-1">
-                        <div className="font-medium text-gray-900">{module.name}</div>
-                        <div className="text-sm text-gray-600">{module.description}</div>
+                        <div className="font-medium text-[var(--text)]">{module.name}</div>
+                        <div className="text-sm text-muted">{module.description}</div>
                       </div>
                     </label>
                   ))}
@@ -229,13 +229,13 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
                       ...settings,
                       createBackup: e.target.checked,
                     })}
-                    className="h-5 w-5 text-purple-600 rounded border-gray-300 mt-0.5"
+                    className="h-5 w-5 text-purple-600 rounded border-[color:var(--surface-muted)] mt-0.5"
                   />
                   <div className="ml-3">
-                    <div className="font-medium text-gray-900">
+                    <div className="font-medium text-[var(--text)]">
                       Create a backup key (recommended)
                     </div>
-                    <div className="text-sm text-gray-600 mt-1">
+                    <div className="text-sm text-muted mt-1">
                       You'll receive a recovery key to store in a safe place
                     </div>
                   </div>
@@ -259,7 +259,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
               {currentStep > 0 && (
                 <button
                   onClick={handleBack}
-                  className="text-gray-600 hover:text-gray-900"
+                  className="text-muted hover:text-[var(--text)]"
                 >
                   Back
                 </button>
@@ -270,7 +270,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
               {showSkip && currentStep === 0 && onSkip && (
                 <button
                   onClick={onSkip}
-                  className="px-4 py-2 text-gray-600 hover:text-gray-900"
+                  className="px-4 py-2 text-muted hover:text-[var(--text)]"
                 >
                   Skip for now
                 </button>
@@ -278,7 +278,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
 
               <button
                 onClick={handleNext}
-                className="flex items-center gap-2 px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+                className="flex items-center gap-2 px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
               >
                 {currentStep === steps.length - 1 ? 'Complete Setup' : 'Continue'}
                 <ArrowRight className="h-4 w-4" />

--- a/frontend/src/components/encryption/EncryptionToggle.tsx
+++ b/frontend/src/components/encryption/EncryptionToggle.tsx
@@ -44,7 +44,7 @@ export const EncryptionToggle: React.FC<EncryptionToggleProps> = ({
         <span
           className={`
             ${value ? 'translate-x-6' : 'translate-x-1'}
-            inline-block h-4 w-4 transform rounded-full bg-white transition-transform
+            inline-block h-4 w-4 transform rounded-full bg-[var(--surface)] transition-transform
           `}
         />
       </button>
@@ -56,7 +56,7 @@ export const EncryptionToggle: React.FC<EncryptionToggleProps> = ({
           <ShieldOff className="h-5 w-5 text-gray-400" aria-hidden="true" />
         )}
         
-        <span className={`text-sm font-medium ${value ? 'text-gray-900' : 'text-gray-500'}`}>
+        <span className={`text-sm font-medium ${value ? 'text-[var(--text)]' : 'text-gray-500'}`}>
           {value ? 'Encrypted' : 'Not encrypted'}
         </span>
       </div>
@@ -69,7 +69,7 @@ export const EncryptionToggle: React.FC<EncryptionToggleProps> = ({
             onMouseLeave={() => setShowTooltip(false)}
             onFocus={() => setShowTooltip(true)}
             onBlur={() => setShowTooltip(false)}
-            className="text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 rounded"
+            className="text-gray-400 hover:text-muted focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] rounded"
             aria-label="Encryption information"
           >
             <Info className="h-4 w-4" />

--- a/frontend/src/components/encryption/KeyManagement.tsx
+++ b/frontend/src/components/encryption/KeyManagement.tsx
@@ -60,13 +60,13 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
       <div className="flex items-center gap-3 mb-4">
         <Key className="w-6 h-6 text-purple-600" />
-        <h3 className="text-lg font-semibold text-gray-900">Key Management</h3>
+        <h3 className="text-lg font-semibold text-[var(--text)]">Key Management</h3>
       </div>
 
-      <p className="text-sm text-gray-600 mb-6">
+      <p className="text-sm text-muted mb-6">
         Backup your encryption keys to ensure you never lose access to your encrypted data.
         Store your backup in a secure location.
       </p>
@@ -94,14 +94,14 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
 
       <div className="space-y-4">
         {/* Backup Status */}
-        <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+        <div className="flex items-center justify-between p-4 bg-[var(--surface-muted)] rounded-lg">
           <div className="flex items-center gap-3">
             <div className={`w-3 h-3 rounded-full ${hasBackup ? 'bg-green-500' : 'bg-amber-500'}`} />
             <div>
-              <p className="text-sm font-medium text-gray-900">
+              <p className="text-sm font-medium text-[var(--text)]">
                 {hasBackup ? 'Backup exists' : 'No backup found'}
               </p>
-              <p className="text-xs text-gray-600">
+              <p className="text-xs text-muted">
                 {hasBackup 
                   ? 'Your keys are backed up securely' 
                   : 'Create a backup to protect your data'
@@ -124,7 +124,7 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
 
           <button
             onClick={() => setShowRestoreDialog(true)}
-            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 border border-[color:var(--surface-muted)] text-gray-700 rounded-md hover:bg-[color:var(--surface-muted)] transition-colors"
           >
             <Upload className="w-4 h-4" />
             Restore from Backup
@@ -135,12 +135,12 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
       {/* Restore Dialog */}
       {showRestoreDialog && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h4 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-[var(--surface)] rounded-lg p-6 max-w-md w-full mx-4">
+            <h4 className="text-lg font-semibold text-[var(--text)] mb-4">
               Restore from Backup
             </h4>
             
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-muted mb-4">
               Enter your backup key to restore your encryption keys. This will replace
               your current keys.
             </p>
@@ -149,7 +149,7 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
               value={restoreKey}
               onChange={(e) => setRestoreKey(e.target.value)}
               placeholder="Paste your backup key here..."
-              className="w-full h-32 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500 resize-none"
+              className="w-full h-32 px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500 resize-none"
               disabled={isRestoring}
             />
 
@@ -161,7 +161,7 @@ const KeyManagement: React.FC<KeyManagementProps> = ({
                   setError(null);
                 }}
                 disabled={isRestoring}
-                className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+                className="flex-1 px-4 py-2 border border-[color:var(--surface-muted)] text-gray-700 rounded-md hover:bg-[color:var(--surface-muted)] transition-colors disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/frontend/src/components/encryption/ShareDialog.tsx
+++ b/frontend/src/components/encryption/ShareDialog.tsx
@@ -116,16 +116,16 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden">
+      <div className="bg-[var(--surface)] rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b">
           <div className="flex items-center gap-3">
             <Share2 className="w-6 h-6 text-purple-600" />
-            <h2 className="text-xl font-semibold text-gray-900">Share Items</h2>
+            <h2 className="text-xl font-semibold text-[var(--text)]">Share Items</h2>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-gray-400 hover:text-muted transition-colors"
           >
             <X className="w-6 h-6" />
           </button>
@@ -149,7 +149,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
               {items.map(item => (
                 <label
                   key={item.id}
-                  className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg hover:bg-gray-100 cursor-pointer transition-colors"
+                  className="flex items-center gap-3 p-3 bg-[var(--surface-muted)] rounded-lg hover:bg-[color:var(--surface-muted)] cursor-pointer transition-colors"
                 >
                   <input
                     type="checkbox"
@@ -158,10 +158,10 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
                     className="w-4 h-4 text-purple-600 rounded focus:ring-purple-500"
                   />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-sm font-medium text-[var(--text)]">
                       {item.title}
                     </p>
-                    <p className="text-xs text-gray-600">
+                    <p className="text-xs text-muted">
                       {item.type} • {new Date(item.createdAt).toLocaleDateString()}
                     </p>
                   </div>
@@ -183,7 +183,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
               value={recipientEmail}
               onChange={(e) => setRecipientEmail(e.target.value)}
               placeholder="recipient@example.com"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
             />
           </div>
 
@@ -231,7 +231,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
             <select
               value={expiresIn}
               onChange={(e) => setExpiresIn(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
             >
               <option value="1h">1 hour</option>
               <option value="24h">24 hours</option>
@@ -256,7 +256,7 @@ const ShareDialog: React.FC<ShareDialogProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 p-6 border-t bg-gray-50">
+        <div className="flex items-center justify-end gap-3 p-6 border-t bg-[var(--surface-muted)]">
           <button
             onClick={onClose}
             disabled={isSharing}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -7,9 +7,9 @@ const AppLayout: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Header 
-        onMobileMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)} 
+    <div className="min-h-screen bg-surface text-theme">
+      <Header
+        onMobileMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
       />
       
       <MobileMenu 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts';
+import { ThemeSwitcher } from '../common';
 
 interface HeaderProps {
   onMobileMenuToggle: () => void;
@@ -35,7 +36,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
   };
 
   return (
-    <header className="bg-white shadow">
+    <header className="bg-surface shadow">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo and Desktop Navigation */}
@@ -46,7 +47,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
                 src="/logo.svg"
                 alt="AI Lifestyle App"
               />
-              <span className="ml-2 text-xl font-semibold text-gray-900 hidden sm:block">
+              <span className="ml-2 text-xl font-semibold text-theme hidden sm:block">
                 AI Lifestyle
               </span>
             </Link>
@@ -56,7 +57,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
               <Link
                 to="/dashboard"
                 className={`${
-                  isActive('/dashboard') ? 'text-gray-900' : 'text-gray-500'
+                  isActive('/dashboard') ? 'text-theme' : 'text-muted'
                 } hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium`}
               >
                 Dashboard
@@ -64,7 +65,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
               <Link
                 to="/goals"
                 className={`${
-                  isActive('/goals') ? 'text-gray-900' : 'text-gray-500'
+                  isActive('/goals') ? 'text-theme' : 'text-muted'
                 } hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium`}
               >
                 Goals
@@ -72,7 +73,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
               <Link
                 to="/meals"
                 className={`${
-                  isActive('/meals') ? 'text-gray-900' : 'text-gray-500'
+                  isActive('/meals') ? 'text-theme' : 'text-muted'
                 } hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium`}
               >
                 Meals
@@ -80,7 +81,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
               <Link
                 to="/workouts"
                 className={`${
-                  isActive('/workouts') ? 'text-gray-900' : 'text-gray-500'
+                  isActive('/workouts') ? 'text-theme' : 'text-muted'
                 } hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium`}
               >
                 Workouts
@@ -88,7 +89,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
               <Link
                 to="/wellness"
                 className={`${
-                  isActive('/wellness') ? 'text-gray-900' : 'text-gray-500'
+                  isActive('/wellness') ? 'text-theme' : 'text-muted'
                 } hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium`}
               >
                 Wellness
@@ -108,7 +109,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
             <div className="relative" ref={userMenuRef}>
               <button
                 type="button"
-                className="flex items-center text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                className="flex items-center text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] focus:ring-primary-500"
                 onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
                 aria-expanded={isUserMenuOpen}
                 aria-haspopup="true"
@@ -119,7 +120,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
                     {user?.firstName?.[0]?.toUpperCase() || 'U'}
                   </span>
                 </div>
-                <span className="hidden md:block ml-2 text-gray-700">
+                <span className="hidden md:block ml-2 text-muted">
                   {user?.firstName} {user?.lastName}
                 </span>
                 <svg
@@ -140,15 +141,15 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
 
               {/* Dropdown Menu */}
               {isUserMenuOpen && (
-                <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+                <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
                   <div className="py-1" role="menu" aria-orientation="vertical">
-                    <div className="px-4 py-2 text-sm text-gray-700 border-b">
+                    <div className="px-4 py-2 text-sm text-muted border-b">
                       <div className="font-medium">{user?.firstName} {user?.lastName}</div>
                       <div className="text-gray-500">{user?.email}</div>
                     </div>
                     <Link
                       to="/profile"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block px-4 py-2 text-sm text-muted hover:bg-[color:var(--surface-muted)]"
                       role="menuitem"
                       onClick={() => setIsUserMenuOpen(false)}
                     >
@@ -156,15 +157,18 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
                     </Link>
                     <Link
                       to="/settings"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block px-4 py-2 text-sm text-muted hover:bg-[color:var(--surface-muted)]"
                       role="menuitem"
                       onClick={() => setIsUserMenuOpen(false)}
                     >
                       Settings
                     </Link>
+                    <div className="px-4 py-2">
+                      <ThemeSwitcher />
+                    </div>
                     <button
                       onClick={handleLogout}
-                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      className="block w-full text-left px-4 py-2 text-sm text-muted hover:bg-[color:var(--surface-muted)]"
                       role="menuitem"
                     >
                       Sign out
@@ -177,7 +181,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
             {/* Mobile menu button */}
             <button
               type="button"
-              className="md:hidden ml-4 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
+              className="md:hidden ml-4 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-[color:var(--surface-muted)] focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
               onClick={onMobileMenuToggle}
             >
               <span className="sr-only">Open main menu</span>

--- a/frontend/src/components/layout/MobileMenu.tsx
+++ b/frontend/src/components/layout/MobileMenu.tsx
@@ -26,17 +26,17 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
       />
 
       {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 max-w-xs w-full bg-white shadow-xl z-50 md:hidden">
+      <div className="fixed inset-y-0 right-0 max-w-xs w-full bg-surface shadow-xl z-50 md:hidden">
         <div className="flex items-center justify-between p-4 border-b">
           <div>
-            <div className="text-base font-medium text-gray-900">
+            <div className="text-base font-medium text-[var(--text)]">
               {user?.firstName} {user?.lastName}
             </div>
             <div className="text-sm text-gray-500">{user?.email}</div>
           </div>
           <button
             type="button"
-            className="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100"
+            className="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-[color:var(--surface-muted)]"
             onClick={onClose}
           >
             <span className="sr-only">Close menu</span>
@@ -61,7 +61,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <Link
             to="/dashboard"
             className={`block px-3 py-2 rounded-md text-base font-medium ${
-              isActive('/dashboard') ? 'text-gray-900 bg-gray-100' : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+              isActive('/dashboard') ? 'text-[var(--text)] bg-[var(--surface-muted)]' : 'text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]'
             }`}
             onClick={onClose}
           >
@@ -70,7 +70,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <Link
             to="/goals"
             className={`block px-3 py-2 rounded-md text-base font-medium ${
-              isActive('/goals') ? 'text-gray-900 bg-gray-100' : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+              isActive('/goals') ? 'text-[var(--text)] bg-[var(--surface-muted)]' : 'text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]'
             }`}
             onClick={onClose}
           >
@@ -79,7 +79,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <Link
             to="/meals"
             className={`block px-3 py-2 rounded-md text-base font-medium ${
-              isActive('/meals') ? 'text-gray-900 bg-gray-100' : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+              isActive('/meals') ? 'text-[var(--text)] bg-[var(--surface-muted)]' : 'text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]'
             }`}
             onClick={onClose}
           >
@@ -88,7 +88,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <Link
             to="/workouts"
             className={`block px-3 py-2 rounded-md text-base font-medium ${
-              isActive('/workouts') ? 'text-gray-900 bg-gray-100' : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+              isActive('/workouts') ? 'text-[var(--text)] bg-[var(--surface-muted)]' : 'text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]'
             }`}
             onClick={onClose}
           >
@@ -97,7 +97,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <Link
             to="/wellness"
             className={`block px-3 py-2 rounded-md text-base font-medium ${
-              isActive('/wellness') ? 'text-gray-900 bg-gray-100' : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+              isActive('/wellness') ? 'text-[var(--text)] bg-[var(--surface-muted)]' : 'text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]'
             }`}
             onClick={onClose}
           >
@@ -109,14 +109,14 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
           <div className="px-2 space-y-1">
             <Link
               to="/profile"
-              className="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+              className="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]"
               onClick={onClose}
             >
               Your Profile
             </Link>
             <Link
               to="/settings"
-              className="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+              className="block px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]"
               onClick={onClose}
             >
               Settings
@@ -126,7 +126,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
                 logout();
                 onClose();
               }}
-              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-500 hover:text-[var(--text)] hover:bg-[color:var(--surface-muted)]"
             >
               Sign out
             </button>

--- a/frontend/src/components/layout/PublicLayout.tsx
+++ b/frontend/src/components/layout/PublicLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const PublicLayout: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-surface text-theme">
       <Outlet />
     </div>
   );

--- a/frontend/src/components/settings/SecuritySection.tsx
+++ b/frontend/src/components/settings/SecuritySection.tsx
@@ -49,20 +49,20 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
   };
 
   return (
-    <div className="bg-white shadow sm:rounded-lg">
+    <div className="bg-[var(--surface)] shadow sm:rounded-lg">
       <div className="px-4 py-5 sm:p-6">
-        <h3 className="text-lg leading-6 font-medium text-gray-900">
+        <h3 className="text-lg leading-6 font-medium text-[var(--text)]">
           Security Settings
         </h3>
         
         {/* Two-Factor Authentication */}
-        <div className="mt-6 border-t border-gray-200 pt-6">
+        <div className="mt-6 border-t border-[color:var(--surface-muted)] pt-6">
           <div className="sm:flex sm:items-start sm:justify-between">
             <div>
-              <h4 className="text-base font-medium text-gray-900">
+              <h4 className="text-base font-medium text-[var(--text)]">
                 Two-Factor Authentication
               </h4>
-              <p className="mt-1 text-sm text-gray-600">
+              <p className="mt-1 text-sm text-muted">
                 Add an extra layer of security to your account by requiring a verification code in addition to your password.
               </p>
             </div>
@@ -96,11 +96,11 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
         </div>
 
         {/* Login History */}
-        <div className="mt-6 border-t border-gray-200 pt-6">
-          <h4 className="text-base font-medium text-gray-900">
+        <div className="mt-6 border-t border-[color:var(--surface-muted)] pt-6">
+          <h4 className="text-base font-medium text-[var(--text)]">
             Recent Login Activity
           </h4>
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-muted">
             Monitor recent login attempts to your account.
           </p>
           <div className="mt-4">
@@ -111,11 +111,11 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
         </div>
 
         {/* Password */}
-        <div className="mt-6 border-t border-gray-200 pt-6">
-          <h4 className="text-base font-medium text-gray-900">
+        <div className="mt-6 border-t border-[color:var(--surface-muted)] pt-6">
+          <h4 className="text-base font-medium text-[var(--text)]">
             Password
           </h4>
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-muted">
             Keep your account secure by using a strong, unique password.
           </p>
           <div className="mt-4">
@@ -138,12 +138,12 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
         <div className="fixed z-50 inset-0 overflow-y-auto">
           <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-              <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+              <div className="absolute inset-0 bg-black/60"></div>
             </div>
 
             <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
 
-            <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+            <div className="inline-block align-bottom bg-[var(--surface)] rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
               <div className="sm:flex sm:items-start">
                 <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
                   <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -151,7 +151,7 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                   </svg>
                 </div>
                 <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                  <h3 className="text-lg leading-6 font-medium text-gray-900">
+                  <h3 className="text-lg leading-6 font-medium text-[var(--text)]">
                     Disable Two-Factor Authentication
                   </h3>
                   <div className="mt-2">
@@ -169,7 +169,7 @@ const SecuritySection: React.FC<SecuritySectionProps> = ({ user }) => {
                       id="password"
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
-                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                      className="mt-1 block w-full border-[color:var(--surface-muted)] rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
                       required
                     />
                     {error && (

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { ThemeContext } from './ThemeContextType';
+import type { Theme } from './ThemeContextType';
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+const THEME_KEY = 'theme-preference';
+const themes: Theme[] = ['dark', 'light', 'reading'];
+
+const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(
+    () => (localStorage.getItem(THEME_KEY) as Theme) || 'dark'
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark', 'reading');
+    root.classList.add(theme);
+    root.classList.toggle('dark', theme === 'dark');
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+
+  const setTheme = (newTheme: Theme) => {
+    if (themes.includes(newTheme)) {
+      setThemeState(newTheme);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/frontend/src/contexts/ThemeContextType.ts
+++ b/frontend/src/contexts/ThemeContextType.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export type Theme = 'dark' | 'light' | 'reading';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -1,3 +1,6 @@
 export { useAuth } from './useAuth';
 export { default as AuthProvider } from './AuthContext';
 export type { AuthContextValue } from './AuthContextType';
+export { useTheme } from './useTheme';
+export { default as ThemeProvider } from './ThemeContext';
+export type { Theme, ThemeContextValue } from './ThemeContextType';

--- a/frontend/src/contexts/useTheme.ts
+++ b/frontend/src/contexts/useTheme.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from './ThemeContextType';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/src/features/auth/components/BackupCodesDisplay.tsx
+++ b/frontend/src/features/auth/components/BackupCodesDisplay.tsx
@@ -106,12 +106,12 @@ Use these codes if you lose access to your authenticator app.
       </div>
 
       {/* Backup Codes Grid */}
-      <div className="bg-gray-50 rounded-lg p-4">
+      <div className="bg-[var(--surface-muted)] rounded-lg p-4">
         <div className="grid grid-cols-2 gap-3">
           {codes.map((code, index) => (
             <div
               key={index}
-              className="bg-white px-3 py-2 rounded border border-gray-200 font-mono text-sm text-center"
+              className="bg-[var(--surface)] px-3 py-2 rounded border border-[color:var(--surface-muted)] font-mono text-sm text-center"
             >
               {code}
             </div>
@@ -180,7 +180,7 @@ Use these codes if you lose access to your authenticator app.
           <input
             type="checkbox"
             id="confirm-saved"
-            className="mt-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+            className="mt-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-[color:var(--surface-muted)] rounded"
             onChange={() => {
               // Could track this state if needed
             }}

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -123,12 +123,12 @@ const LoginForm: React.FC = () => {
   if (showMfa && mfaSession) {
     return (
       <div className="w-full max-w-md mx-auto">
-        <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+        <div className="bg-[var(--surface)] py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
           <div className="mb-6">
-            <h2 className="text-center text-3xl font-extrabold text-gray-900">
+            <h2 className="text-center text-3xl font-extrabold text-[var(--text)]">
               Two-Factor Authentication
             </h2>
-            <p className="mt-2 text-center text-sm text-gray-600">
+            <p className="mt-2 text-center text-sm text-muted">
               Enter the 6-digit code from your authenticator app
             </p>
           </div>
@@ -165,12 +165,12 @@ const LoginForm: React.FC = () => {
 
   return (
     <div className="w-full max-w-md mx-auto">
-      <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+      <div className="bg-[var(--surface)] py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
         <div className="mb-6">
-          <h2 className="text-center text-3xl font-extrabold text-gray-900">
+          <h2 className="text-center text-3xl font-extrabold text-[var(--text)]">
             Sign in to your account
           </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
+          <p className="mt-2 text-center text-sm text-muted">
             Or{' '}
             <Link
               to="/register"
@@ -223,10 +223,10 @@ const LoginForm: React.FC = () => {
               <input
                 id="rememberMe"
                 type="checkbox"
-                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-[color:var(--surface-muted)] rounded"
                 {...register('rememberMe')}
               />
-              <label htmlFor="rememberMe" className="ml-2 block text-sm text-gray-900">
+              <label htmlFor="rememberMe" className="ml-2 block text-sm text-[var(--text)]">
                 Remember me
               </label>
             </div>
@@ -255,10 +255,10 @@ const LoginForm: React.FC = () => {
         <div className="mt-6">
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300" />
+              <div className="w-full border-t border-[color:var(--surface-muted)]" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-white text-gray-500">Or continue with</span>
+              <span className="px-2 bg-[var(--surface)] text-gray-500">Or continue with</span>
             </div>
           </div>
 

--- a/frontend/src/features/auth/components/MFASetupModal.tsx
+++ b/frontend/src/features/auth/components/MFASetupModal.tsx
@@ -32,8 +32,8 @@ const SimpleModal: React.FC<{
       
       {/* Modal */}
       <div className="flex min-h-full items-center justify-center p-4">
-        <div className="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left shadow-xl">
-          <h3 className="text-lg font-medium leading-6 text-gray-900 mb-4">
+        <div className="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-[var(--surface)] p-6 text-left shadow-xl">
+          <h3 className="text-lg font-medium leading-6 text-[var(--text)] mb-4">
             {title}
           </h3>
           {children}
@@ -160,10 +160,10 @@ const MFASetupModal: React.FC<MFASetupModalProps> = ({
         return (
           <>
             <div className="text-center mb-6">
-              <h3 className="text-lg font-medium text-gray-900">
+              <h3 className="text-lg font-medium text-[var(--text)]">
                 Verify Your Setup
               </h3>
-              <p className="mt-2 text-sm text-gray-600">
+              <p className="mt-2 text-sm text-muted">
                 Enter the 6-digit code from your authenticator app to complete setup
               </p>
             </div>

--- a/frontend/src/features/auth/components/MfaCodeInput.tsx
+++ b/frontend/src/features/auth/components/MfaCodeInput.tsx
@@ -89,9 +89,9 @@ const MfaCodeInput: React.FC<MfaCodeInputProps> = ({
               border-2 transition-colors
               ${error 
                 ? 'border-red-300 focus:border-red-500 focus:ring-red-500' 
-                : 'border-gray-300 focus:border-primary-500 focus:ring-primary-500'
+                : 'border-[color:var(--surface-muted)] focus:border-primary-500 focus:ring-primary-500'
               }
-              focus:outline-none focus:ring-2 focus:ring-offset-2
+              focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]
               disabled:opacity-50 disabled:cursor-not-allowed
             `}
             disabled={isLoading}
@@ -109,7 +109,7 @@ const MfaCodeInput: React.FC<MfaCodeInputProps> = ({
         <button
           type="submit"
           disabled={code.some(digit => digit === '') || isLoading}
-          className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isLoading ? 'Verifying...' : 'Verify'}
         </button>
@@ -118,7 +118,7 @@ const MfaCodeInput: React.FC<MfaCodeInputProps> = ({
             type="button"
             onClick={onCancel}
             disabled={isLoading}
-            className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 inline-flex justify-center items-center px-4 py-2 border border-[color:var(--surface-muted)] text-sm font-medium rounded-md text-gray-700 bg-[var(--surface)] hover:bg-[color:var(--surface-muted)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cancel
           </button>

--- a/frontend/src/features/auth/components/PasswordInput.tsx
+++ b/frontend/src/features/auth/components/PasswordInput.tsx
@@ -14,7 +14,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
       <button
         type="button"
         onClick={() => setShowPassword(!showPassword)}
-        className="text-gray-400 hover:text-gray-600 focus:outline-none focus:text-gray-600"
+        className="text-gray-400 hover:text-muted focus:outline-none focus:text-muted"
         aria-label={showPassword ? 'Hide password' : 'Show password'}
       >
         {showPassword ? (

--- a/frontend/src/features/auth/components/PasswordStrengthMeter.tsx
+++ b/frontend/src/features/auth/components/PasswordStrengthMeter.tsx
@@ -20,7 +20,7 @@ const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({
   return (
     <div className="mt-2">
       <div className="flex items-center justify-between mb-1">
-        <span className="text-sm text-gray-600">Password strength:</span>
+        <span className="text-sm text-muted">Password strength:</span>
         <span className={clsx(
           'text-sm font-medium',
           strength.score === 0 && 'text-red-600',
@@ -51,7 +51,7 @@ const PasswordStrengthMeter: React.FC<PasswordStrengthMeterProps> = ({
       {showFeedback && strength.feedback.length > 0 && (
         <ul className="mt-2 space-y-1">
           {strength.feedback.map((feedback, index) => (
-            <li key={index} className="text-xs text-gray-600 flex items-start">
+            <li key={index} className="text-xs text-muted flex items-start">
               <svg
                 className="h-3 w-3 text-gray-400 mt-0.5 mr-1 flex-shrink-0"
                 fill="currentColor"

--- a/frontend/src/features/auth/components/QRCodeDisplay.tsx
+++ b/frontend/src/features/auth/components/QRCodeDisplay.tsx
@@ -19,12 +19,12 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <p className="text-sm text-gray-600 mb-4">
+        <p className="text-sm text-muted mb-4">
           Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)
         </p>
         
         {/* QR Code Image */}
-        <div className="inline-block p-4 bg-white border-2 border-gray-200 rounded-lg">
+        <div className="inline-block p-4 bg-[var(--surface)] border-2 border-[color:var(--surface-muted)] rounded-lg">
           <img
             src={qrCode}
             alt="2FA QR Code"
@@ -44,18 +44,18 @@ const QRCodeDisplay: React.FC<QRCodeDisplayProps> = ({
         </button>
         
         {showSecret && (
-          <div className="mt-3 p-3 bg-gray-50 rounded-md">
-            <p className="text-xs text-gray-600 mb-2">
+          <div className="mt-3 p-3 bg-[var(--surface-muted)] rounded-md">
+            <p className="text-xs text-muted mb-2">
               Enter this secret key in your authenticator app:
             </p>
             <div className="flex items-center justify-between">
-              <code className="text-sm font-mono bg-white px-3 py-1 rounded border border-gray-200">
+              <code className="text-sm font-mono bg-[var(--surface)] px-3 py-1 rounded border border-[color:var(--surface-muted)]">
                 {secret}
               </code>
               <button
                 type="button"
                 onClick={() => navigator.clipboard.writeText(secret)}
-                className="ml-2 p-1 text-gray-400 hover:text-gray-600"
+                className="ml-2 p-1 text-gray-400 hover:text-muted"
                 title="Copy to clipboard"
               >
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/features/auth/components/RegistrationForm.tsx
+++ b/frontend/src/features/auth/components/RegistrationForm.tsx
@@ -94,12 +94,12 @@ const RegistrationForm: React.FC = () => {
 
   return (
     <div className="w-full max-w-md mx-auto">
-      <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+      <div className="bg-[var(--surface)] py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
         <div className="mb-6">
-          <h2 className="text-center text-3xl font-extrabold text-gray-900">
+          <h2 className="text-center text-3xl font-extrabold text-[var(--text)]">
             Create your account
           </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
+          <p className="mt-2 text-center text-sm text-muted">
             Already have an account?{' '}
             <Link
               to="/login"
@@ -187,10 +187,10 @@ const RegistrationForm: React.FC = () => {
               <input
                 id="terms"
                 type="checkbox"
-                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-[color:var(--surface-muted)] rounded"
                 required
               />
-              <label htmlFor="terms" className="ml-2 block text-sm text-gray-900">
+              <label htmlFor="terms" className="ml-2 block text-sm text-[var(--text)]">
                 I agree to the{' '}
                 <Link
                   to="/terms"
@@ -225,10 +225,10 @@ const RegistrationForm: React.FC = () => {
         <div className="mt-6">
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300" />
+              <div className="w-full border-t border-[color:var(--surface-muted)]" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-white text-gray-500">Or continue with</span>
+              <span className="px-2 bg-[var(--surface)] text-gray-500">Or continue with</span>
             </div>
           </div>
 

--- a/frontend/src/features/auth/components/RegistrationSuccess.tsx
+++ b/frontend/src/features/auth/components/RegistrationSuccess.tsx
@@ -14,7 +14,7 @@ const RegistrationSuccess: React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+        <div className="bg-[var(--surface)] py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <div className="text-center">
             {/* Success Icon */}
             <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
@@ -33,16 +33,16 @@ const RegistrationSuccess: React.FC = () => {
               </svg>
             </div>
 
-            <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+            <h2 className="mt-6 text-3xl font-extrabold text-[var(--text)]">
               Registration successful!
             </h2>
 
             <div className="mt-4 space-y-4">
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted">
                 {state.message || `We've sent a verification email to:`}
               </p>
               
-              <p className="text-sm font-medium text-gray-900">
+              <p className="text-sm font-medium text-[var(--text)]">
                 {state.email}
               </p>
 

--- a/frontend/src/features/auth/components/SetupInstructions.tsx
+++ b/frontend/src/features/auth/components/SetupInstructions.tsx
@@ -20,14 +20,14 @@ const SetupInstructions: React.FC = () => {
             />
           </svg>
         </div>
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-muted">
           Two-factor authentication adds an extra layer of security to your account by requiring a code from your phone in addition to your password.
         </p>
       </div>
 
       {/* Steps */}
       <div className="space-y-4">
-        <h4 className="text-sm font-medium text-gray-900">What you'll need:</h4>
+        <h4 className="text-sm font-medium text-[var(--text)]">What you'll need:</h4>
         
         <div className="space-y-3">
           {/* Step 1 */}
@@ -38,10 +38,10 @@ const SetupInstructions: React.FC = () => {
               </div>
             </div>
             <div className="ml-3">
-              <h5 className="text-sm font-medium text-gray-900">
+              <h5 className="text-sm font-medium text-[var(--text)]">
                 A smartphone with an authenticator app
               </h5>
-              <p className="text-sm text-gray-600 mt-1">
+              <p className="text-sm text-muted mt-1">
                 Install Google Authenticator, Microsoft Authenticator, Authy, or similar
               </p>
             </div>
@@ -55,10 +55,10 @@ const SetupInstructions: React.FC = () => {
               </div>
             </div>
             <div className="ml-3">
-              <h5 className="text-sm font-medium text-gray-900">
+              <h5 className="text-sm font-medium text-[var(--text)]">
                 5 minutes to complete setup
               </h5>
-              <p className="text-sm text-gray-600 mt-1">
+              <p className="text-sm text-muted mt-1">
                 You'll scan a QR code and save backup codes
               </p>
             </div>
@@ -72,10 +72,10 @@ const SetupInstructions: React.FC = () => {
               </div>
             </div>
             <div className="ml-3">
-              <h5 className="text-sm font-medium text-gray-900">
+              <h5 className="text-sm font-medium text-[var(--text)]">
                 A secure place to store backup codes
               </h5>
-              <p className="text-sm text-gray-600 mt-1">
+              <p className="text-sm text-muted mt-1">
                 You'll receive codes to use if you lose your phone
               </p>
             </div>

--- a/frontend/src/features/goals/components/GoalCreator/GoalTypeSelector.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/GoalTypeSelector.tsx
@@ -58,10 +58,10 @@ export const GoalTypeSelector: React.FC<GoalTypeSelectorProps> = ({
   return (
     <div className={`space-y-6 ${className}`}>
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+        <h2 className="text-2xl font-bold text-[var(--text)] mb-2">
           What type of goal do you want to set?
         </h2>
-        <p className="text-gray-600">
+        <p className="text-muted">
           Choose the pattern that best fits what you want to achieve
         </p>
       </div>
@@ -73,7 +73,7 @@ export const GoalTypeSelector: React.FC<GoalTypeSelectorProps> = ({
             <button
               key={config.pattern}
               onClick={() => onSelectType(config.pattern)}
-              className="group relative bg-white rounded-xl border-2 border-gray-200 p-6 text-left hover:border-gray-300 hover:shadow-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+              className="group relative bg-[var(--surface)] rounded-xl border-2 border-[color:var(--surface-muted)] p-6 text-left hover:border-[color:var(--surface-muted)] hover:shadow-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)] focus:ring-purple-500"
               aria-label={`Select ${config.title}`}
             >
               {/* Pattern indicator */}
@@ -94,12 +94,12 @@ export const GoalTypeSelector: React.FC<GoalTypeSelectorProps> = ({
 
                 <div>
                   <h3
-                    className="font-semibold text-gray-900 mb-1"
+                    className="font-semibold text-[var(--text)] mb-1"
                     style={{ color: config.color }}
                   >
                     {config.title}
                   </h3>
-                  <p className="text-sm text-gray-600 mb-2">
+                  <p className="text-sm text-muted mb-2">
                     {config.description}
                   </p>
                   <p className="text-xs text-gray-500 italic">

--- a/frontend/src/features/goals/components/GoalCreator/LimitGoalForm.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/LimitGoalForm.tsx
@@ -109,8 +109,8 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
           <ShieldAlert className="h-6 w-6 text-red-600" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Create Limit Goal</h3>
-          <p className="text-sm text-gray-600">Set boundaries to stay within healthy limits</p>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Create Limit Goal</h3>
+          <p className="text-sm text-muted">Set boundaries to stay within healthy limits</p>
         </div>
       </div>
 
@@ -131,8 +131,8 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               <div className="flex items-center gap-2">
                 <span className="text-lg">{template.icon}</span>
                 <div className="flex-1">
-                  <div className="text-sm font-medium text-gray-900">{template.title}</div>
-                  <div className="text-xs text-gray-600">
+                  <div className="text-sm font-medium text-[var(--text)]">{template.title}</div>
+                  <div className="text-xs text-muted">
                     Max {template.limitValue} {template.unit}/{template.period}
                   </div>
                 </div>
@@ -153,7 +153,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
           value={formData.title}
           onChange={(e) => updateFormData({ title: e.target.value })}
           placeholder="e.g., Limit screen time"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
           required
         />
       </div>
@@ -167,7 +167,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
           id="category"
           value={formData.category}
           onChange={(e) => updateFormData({ category: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
           required
         >
           {GOAL_CATEGORIES.map(cat => (
@@ -180,7 +180,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
 
       {/* Limit Configuration */}
       <div className="bg-red-50 rounded-lg p-4 space-y-4">
-        <h4 className="font-medium text-gray-900 flex items-center gap-2">
+        <h4 className="font-medium text-[var(--text)] flex items-center gap-2">
           <ShieldAlert className="h-4 w-4 text-red-600" />
           Set your limit
         </h4>
@@ -197,7 +197,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               className={`flex-1 py-2 px-4 rounded-lg border-2 transition-colors ${
                 formData.targetType === 'maximum'
                   ? 'border-red-500 bg-red-50 text-red-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
               }`}
             >
               Maximum (stay under)
@@ -208,7 +208,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               className={`flex-1 py-2 px-4 rounded-lg border-2 transition-colors ${
                 formData.targetType === 'minimum'
                   ? 'border-red-500 bg-red-50 text-red-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
               }`}
             >
               Minimum (stay above)
@@ -229,7 +229,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               onChange={(e) => updateFormData({ limitValue: parseFloat(e.target.value) || 0 })}
               min={0}
               step="0.1"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
               required
             />
           </div>
@@ -247,7 +247,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
                   setMetricType(newType);
                   updateFormData({ unit: METRIC_UNITS[newType][0] || '' });
                 }}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
               >
                 <option value="duration">Duration</option>
                 <option value="amount">Amount</option>
@@ -259,7 +259,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
                 id="unit"
                 value={formData.unit}
                 onChange={(e) => updateFormData({ unit: e.target.value })}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
                 required
               >
                 {availableUnits.map(unit => (
@@ -278,7 +278,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               id="period"
               value={formData.period}
               onChange={(e) => updateFormData({ period: e.target.value as Period })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
               required
             >
               {periods.map(period => (
@@ -329,7 +329,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
           onChange={(e) => updateFormData({ description: e.target.value })}
           placeholder="Why is this limit important? What are you trying to achieve?"
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
         />
       </div>
 
@@ -355,7 +355,7 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
               onChange={(e) => setPrivateNotes(e.target.value)}
               placeholder="Your triggers, alternatives, or coping strategies (encrypted)..."
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
             />
             <p className="text-xs text-gray-500 mt-1">
               🔒 These notes will be encrypted and only visible to you
@@ -369,13 +369,13 @@ export const LimitGoalForm: React.FC<LimitGoalFormProps> = ({
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          className="px-4 py-2 text-gray-700 hover:text-[var(--text)]"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+          className="px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           Create Goal
         </button>

--- a/frontend/src/features/goals/components/GoalCreator/MilestoneGoalForm.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/MilestoneGoalForm.tsx
@@ -64,8 +64,8 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
           <Trophy className="h-6 w-6 text-purple-600" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Create Milestone Goal</h3>
-          <p className="text-sm text-gray-600">Set a cumulative target to achieve</p>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Create Milestone Goal</h3>
+          <p className="text-sm text-muted">Set a cumulative target to achieve</p>
         </div>
       </div>
 
@@ -80,7 +80,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
           value={formData.title}
           onChange={(e) => updateFormData({ title: e.target.value })}
           placeholder="e.g., Write my first novel"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
           required
         />
       </div>
@@ -94,7 +94,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
           id="category"
           value={formData.category}
           onChange={(e) => updateFormData({ category: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
           required
         >
           {GOAL_CATEGORIES.map(cat => (
@@ -107,7 +107,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
 
       {/* Milestone Configuration */}
       <div className="bg-purple-50 rounded-lg p-4 space-y-4">
-        <h4 className="font-medium text-gray-900 flex items-center gap-2">
+        <h4 className="font-medium text-[var(--text)] flex items-center gap-2">
           <TrendingUp className="h-4 w-4 text-purple-600" />
           What milestone do you want to reach?
         </h4>
@@ -124,7 +124,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
               value={formData.targetValue}
               onChange={(e) => updateFormData({ targetValue: parseInt(e.target.value) || 0 })}
               min={1}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
               required
             />
           </div>
@@ -142,7 +142,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
                   setMetricType(newType);
                   updateFormData({ unit: METRIC_UNITS[newType][0] || '' });
                 }}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
               >
                 <option value="count">Count</option>
                 <option value="amount">Amount</option>
@@ -153,7 +153,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
                 id="unit"
                 value={formData.unit}
                 onChange={(e) => updateFormData({ unit: e.target.value })}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                 required
               >
                 {availableUnits.map(unit => (
@@ -175,7 +175,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
               onChange={(e) => updateFormData({ currentValue: parseInt(e.target.value) || 0 })}
               min={0}
               max={formData.targetValue}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
             />
           </div>
         </div>
@@ -194,7 +194,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
               targetDate: e.target.value ? new Date(e.target.value) : undefined 
             })}
             min={new Date().toISOString().split('T')[0]}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
           />
           <p className="text-xs text-gray-500 mt-1">
             Add a deadline to help stay motivated
@@ -231,7 +231,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
           onChange={(e) => updateFormData({ description: e.target.value })}
           placeholder="What does achieving this milestone mean to you?"
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
         />
       </div>
 
@@ -257,7 +257,7 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
               onChange={(e) => setPrivateNotes(e.target.value)}
               placeholder="Your motivation, milestones along the way, or personal thoughts (encrypted)..."
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
             />
             <p className="text-xs text-gray-500 mt-1">
               🔒 These notes will be encrypted and only visible to you
@@ -271,13 +271,13 @@ export const MilestoneGoalForm: React.FC<MilestoneGoalFormProps> = ({
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          className="px-4 py-2 text-gray-700 hover:text-[var(--text)]"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+          className="px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           Create Goal
         </button>

--- a/frontend/src/features/goals/components/GoalCreator/RecurringGoalForm.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/RecurringGoalForm.tsx
@@ -95,8 +95,8 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
           <Repeat className="h-6 w-6 text-blue-600" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Create Recurring Goal</h3>
-          <p className="text-sm text-gray-600">Set up a goal you'll work on regularly</p>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Create Recurring Goal</h3>
+          <p className="text-sm text-muted">Set up a goal you'll work on regularly</p>
         </div>
       </div>
 
@@ -111,7 +111,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
           value={formData.title}
           onChange={(e) => updateFormData({ title: e.target.value })}
           placeholder="e.g., Exercise regularly"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           required
         />
       </div>
@@ -125,7 +125,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
           id="category"
           value={formData.category}
           onChange={(e) => updateFormData({ category: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           required
         >
           {GOAL_CATEGORIES.map(cat => (
@@ -138,7 +138,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
 
       {/* Target Configuration */}
       <div className="bg-blue-50 rounded-lg p-4 space-y-4">
-        <h4 className="font-medium text-gray-900 flex items-center gap-2">
+        <h4 className="font-medium text-[var(--text)] flex items-center gap-2">
           <Calendar className="h-4 w-4 text-blue-600" />
           How often do you want to do this?
         </h4>
@@ -155,7 +155,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
               value={formData.targetValue}
               onChange={(e) => updateFormData({ targetValue: parseInt(e.target.value) || 1 })}
               min={1}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             />
           </div>
@@ -173,7 +173,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
                   setMetricType(newType);
                   updateFormData({ unit: METRIC_UNITS[newType][0] || '' });
                 }}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               >
                 <option value="count">Count</option>
                 <option value="duration">Duration</option>
@@ -184,7 +184,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
                 id="unit"
                 value={formData.unit}
                 onChange={(e) => updateFormData({ unit: e.target.value })}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
               >
                 {availableUnits.map(unit => (
@@ -203,7 +203,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
               id="period"
               value={formData.period}
               onChange={(e) => updateFormData({ period: e.target.value as Period })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             >
               {periods.map(period => (
@@ -226,7 +226,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
                 className={`flex-1 text-center py-2 px-4 rounded-lg border-2 cursor-pointer transition-colors ${
                   formData.frequency === freq.value
                     ? 'border-blue-500 bg-blue-50 text-blue-700'
-                    : 'border-gray-200 hover:border-gray-300'
+                    : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
                 }`}
               >
                 <input
@@ -258,7 +258,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
                   className={`w-10 h-10 rounded-full text-sm font-medium transition-colors ${
                     formData.daysOfWeek?.includes(day.value)
                       ? 'bg-blue-500 text-white'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                   }`}
                   aria-label={day.label}
                 >
@@ -289,7 +289,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
           onChange={(e) => updateFormData({ description: e.target.value })}
           placeholder="Add more details about your goal..."
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
         />
       </div>
 
@@ -315,7 +315,7 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
               onChange={(e) => setPrivateNotes(e.target.value)}
               placeholder="Your motivation, obstacles, or personal thoughts (encrypted)..."
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
             <p className="text-xs text-gray-500 mt-1">
               🔒 These notes will be encrypted and only visible to you
@@ -329,13 +329,13 @@ export const RecurringGoalForm: React.FC<RecurringGoalFormProps> = ({
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          className="px-4 py-2 text-gray-700 hover:text-[var(--text)]"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           Create Goal
         </button>

--- a/frontend/src/features/goals/components/GoalCreator/StreakGoalForm.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/StreakGoalForm.tsx
@@ -78,8 +78,8 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
           <Flame className="h-6 w-6 text-orange-600" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Create Streak Goal</h3>
-          <p className="text-sm text-gray-600">Build momentum with consecutive daily habits</p>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Create Streak Goal</h3>
+          <p className="text-sm text-muted">Build momentum with consecutive daily habits</p>
         </div>
       </div>
 
@@ -100,8 +100,8 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
               <div className="flex items-center gap-2">
                 <span className="text-lg">{template.icon}</span>
                 <div className="flex-1">
-                  <div className="text-sm font-medium text-gray-900">{template.title}</div>
-                  <div className="text-xs text-gray-600">
+                  <div className="text-sm font-medium text-[var(--text)]">{template.title}</div>
+                  <div className="text-xs text-muted">
                     {template.targetStreak} {template.unit}
                   </div>
                 </div>
@@ -122,7 +122,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
           value={formData.title}
           onChange={(e) => updateFormData({ title: e.target.value })}
           placeholder="e.g., 30 days of meditation"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
           required
         />
       </div>
@@ -136,7 +136,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
           id="category"
           value={formData.category}
           onChange={(e) => updateFormData({ category: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
           required
         >
           {GOAL_CATEGORIES.map(cat => (
@@ -149,7 +149,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
 
       {/* Streak Configuration */}
       <div className="bg-orange-50 rounded-lg p-4 space-y-4">
-        <h4 className="font-medium text-gray-900 flex items-center gap-2">
+        <h4 className="font-medium text-[var(--text)] flex items-center gap-2">
           <Calendar className="h-4 w-4 text-orange-600" />
           How long do you want your streak to be?
         </h4>
@@ -167,13 +167,13 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
                 value={formData.targetStreak}
                 onChange={(e) => updateFormData({ targetStreak: parseInt(e.target.value) || 1 })}
                 min={1}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
                 required
               />
               <select
                 value={formData.unit}
                 onChange={(e) => updateFormData({ unit: e.target.value })}
-                className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                className="px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
               >
                 <option value="days">Days</option>
                 <option value="weeks">Weeks</option>
@@ -191,7 +191,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
               id="frequency"
               value={formData.frequency}
               onChange={(e) => updateFormData({ frequency: e.target.value as Frequency })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
             >
               <option value="daily">Daily</option>
               <option value="weekly">Weekly</option>
@@ -242,9 +242,9 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
         </div>
 
         {/* Motivation Tips */}
-        <div className="bg-white rounded-lg p-3 border border-orange-200">
-          <h5 className="text-sm font-medium text-gray-900 mb-2">💡 Tips for Success</h5>
-          <ul className="text-xs text-gray-600 space-y-1">
+        <div className="bg-[var(--surface)] rounded-lg p-3 border border-orange-200">
+          <h5 className="text-sm font-medium text-[var(--text)] mb-2">💡 Tips for Success</h5>
+          <ul className="text-xs text-muted space-y-1">
             <li>• Start small - even 1 minute counts!</li>
             <li>• Set a specific time each day</li>
             <li>• Track visually to stay motivated</li>
@@ -264,7 +264,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
           onChange={(e) => updateFormData({ description: e.target.value })}
           placeholder="What habit are you building? Why is it important?"
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
         />
       </div>
 
@@ -290,7 +290,7 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
               onChange={(e) => setPrivateNotes(e.target.value)}
               placeholder="Your triggers, coping strategies, or personal motivations (encrypted)..."
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
             />
             <p className="text-xs text-gray-500 mt-1">
               🔒 These notes will be encrypted and only visible to you
@@ -304,13 +304,13 @@ export const StreakGoalForm: React.FC<StreakGoalFormProps> = ({
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          className="px-4 py-2 text-gray-700 hover:text-[var(--text)]"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
+          className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           Create Goal
         </button>

--- a/frontend/src/features/goals/components/GoalCreator/TargetGoalForm.tsx
+++ b/frontend/src/features/goals/components/GoalCreator/TargetGoalForm.tsx
@@ -73,8 +73,8 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
           <Target className="h-6 w-6 text-green-600" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Create Target Goal</h3>
-          <p className="text-sm text-gray-600">Set a specific target to reach by a deadline</p>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Create Target Goal</h3>
+          <p className="text-sm text-muted">Set a specific target to reach by a deadline</p>
         </div>
       </div>
 
@@ -89,7 +89,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
           value={formData.title}
           onChange={(e) => updateFormData({ title: e.target.value })}
           placeholder="e.g., Reach my ideal weight"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
           required
         />
       </div>
@@ -103,7 +103,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
           id="category"
           value={formData.category}
           onChange={(e) => updateFormData({ category: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
           required
         >
           {GOAL_CATEGORIES.map(cat => (
@@ -116,7 +116,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
 
       {/* Target Configuration */}
       <div className="bg-green-50 rounded-lg p-4 space-y-4">
-        <h4 className="font-medium text-gray-900 flex items-center gap-2">
+        <h4 className="font-medium text-[var(--text)] flex items-center gap-2">
           <Target className="h-4 w-4 text-green-600" />
           Define your target
         </h4>
@@ -133,7 +133,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
               className={`flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg border-2 transition-colors ${
                 formData.direction === 'increase'
                   ? 'border-green-500 bg-green-50 text-green-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
               }`}
             >
               <TrendingUp className="h-4 w-4" />
@@ -145,7 +145,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
               className={`flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg border-2 transition-colors ${
                 formData.direction === 'decrease'
                   ? 'border-green-500 bg-green-50 text-green-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
               }`}
             >
               <TrendingDown className="h-4 w-4" />
@@ -166,7 +166,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
               value={formData.startValue}
               onChange={(e) => updateFormData({ startValue: parseFloat(e.target.value) || 0 })}
               step="0.1"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
               required
             />
           </div>
@@ -182,7 +182,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
               value={formData.targetValue}
               onChange={(e) => updateFormData({ targetValue: parseFloat(e.target.value) || 0 })}
               step="0.1"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
               required
             />
           </div>
@@ -200,7 +200,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
                   setMetricType(newType);
                   updateFormData({ unit: METRIC_UNITS[newType][0] || '' });
                 }}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
               >
                 <option value="weight">Weight</option>
                 <option value="distance">Distance</option>
@@ -213,7 +213,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
                 id="unit"
                 value={formData.unit}
                 onChange={(e) => updateFormData({ unit: e.target.value })}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
                 required
               >
                 {availableUnits.map(unit => (
@@ -236,7 +236,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
             value={formData.targetDate.toISOString().split('T')[0]}
             onChange={(e) => updateFormData({ targetDate: new Date(e.target.value) })}
             min={new Date().toISOString().split('T')[0]}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+            className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
             required
           />
         </div>
@@ -282,7 +282,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
           onChange={(e) => updateFormData({ description: e.target.value })}
           placeholder="Why is this target important to you?"
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
         />
       </div>
 
@@ -308,7 +308,7 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
               onChange={(e) => setPrivateNotes(e.target.value)}
               placeholder="Your strategy, obstacles to overcome, or personal thoughts (encrypted)..."
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500"
             />
             <p className="text-xs text-gray-500 mt-1">
               🔒 These notes will be encrypted and only visible to you
@@ -322,13 +322,13 @@ export const TargetGoalForm: React.FC<TargetGoalFormProps> = ({
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          className="px-4 py-2 text-gray-700 hover:text-[var(--text)]"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+          className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           Create Goal
         </button>

--- a/frontend/src/features/goals/components/GoalDetail.tsx
+++ b/frontend/src/features/goals/components/GoalDetail.tsx
@@ -104,11 +104,11 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
   return (
     <div className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
         <div className="flex items-start justify-between mb-4">
           <button
             onClick={onBack}
-            className="flex items-center gap-2 text-gray-600 hover:text-gray-900"
+            className="flex items-center gap-2 text-muted hover:text-[var(--text)]"
           >
             <ArrowLeft className="h-5 w-5" />
             Back to Goals
@@ -117,20 +117,20 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
           <div className="relative">
             <button
               onClick={() => setShowActions(!showActions)}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-2 hover:bg-[color:var(--surface-muted)] rounded-lg transition-colors"
               aria-label="Goal actions"
             >
               <MoreVertical className="h-5 w-5 text-gray-500" />
             </button>
             
             {showActions && (
-              <div className="absolute right-0 top-10 z-10 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1">
+              <div className="absolute right-0 top-10 z-10 w-48 bg-[var(--surface)] rounded-lg shadow-lg border border-[color:var(--surface-muted)] py-1">
                 <button
                   onClick={() => {
                     onEdit(goal);
                     setShowActions(false);
                   }}
-                  className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                  className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                 >
                   <Edit2 className="h-4 w-4" />
                   Edit Goal
@@ -141,7 +141,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     setShowShareDialog(true);
                     setShowActions(false);
                   }}
-                  className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                  className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                 >
                   <Share2 className="h-4 w-4" />
                   Share Goal
@@ -153,7 +153,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                       onUpdateStatus('paused');
                       setShowActions(false);
                     }}
-                    className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                    className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                   >
                     <Pause className="h-4 w-4" />
                     Pause Goal
@@ -164,7 +164,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                       onUpdateStatus('active');
                       setShowActions(false);
                     }}
-                    className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                    className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                   >
                     <Play className="h-4 w-4" />
                     Resume Goal
@@ -176,7 +176,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     onUpdateStatus('completed');
                     setShowActions(false);
                   }}
-                  className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                  className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                 >
                   <CheckCircle className="h-4 w-4" />
                   Mark Complete
@@ -187,7 +187,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     onUpdateStatus('archived');
                     setShowActions(false);
                   }}
-                  className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+                  className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
                 >
                   <Archive className="h-4 w-4" />
                   Archive Goal
@@ -221,9 +221,9 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
           </div>
           
           <div className="flex-1">
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">{goal.title}</h1>
+            <h1 className="text-2xl font-bold text-[var(--text)] mb-2">{goal.title}</h1>
             {goal.description && (
-              <p className="text-gray-600">{goal.description}</p>
+              <p className="text-muted">{goal.description}</p>
             )}
             
             <div className="flex items-center gap-4 mt-3">
@@ -240,7 +240,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                 goal.status === 'active' ? 'bg-green-100 text-green-700' :
                 goal.status === 'completed' ? 'bg-blue-100 text-blue-700' :
                 goal.status === 'paused' ? 'bg-yellow-100 text-yellow-700' :
-                'bg-gray-100 text-gray-700'
+                'bg-[var(--surface-muted)] text-gray-700'
               }`}>
                 {goal.status}
               </span>
@@ -262,7 +262,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
               color={color}
               size={120}
             />
-            <p className="text-sm text-gray-600 mt-2">
+            <p className="text-sm text-muted mt-2">
               {goal.progress.trend} trend
             </p>
           </div>
@@ -270,13 +270,13 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+      <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+        <h2 className="text-lg font-semibold text-[var(--text)] mb-4">Quick Actions</h2>
         
         {!showLogForm ? (
           <button
             onClick={() => setShowLogForm(true)}
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors"
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-[var(--surface-muted)] hover:bg-[color:var(--surface-muted)] rounded-lg transition-colors"
             style={{ borderColor: color }}
           >
             <Plus className="h-5 w-5" style={{ color }} />
@@ -296,9 +296,9 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     onChange={(e) => setActivityValue(parseFloat(e.target.value) || 0)}
                     min={0}
                     step="0.1"
-                    className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                    className="flex-1 px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                   />
-                  <span className="px-3 py-2 bg-gray-50 border border-gray-300 rounded-lg text-gray-600">
+                  <span className="px-3 py-2 bg-[var(--surface-muted)] border border-[color:var(--surface-muted)] rounded-lg text-muted">
                     {goal.target.unit}
                   </span>
                 </div>
@@ -308,7 +308,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   When
                 </label>
-                <select className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
+                <select className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
                   <option>Today</option>
                   <option>Yesterday</option>
                   <option>Custom date...</option>
@@ -325,7 +325,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                 onChange={(e) => setActivityNote(e.target.value)}
                 placeholder="How did it go?"
                 rows={2}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
               />
             </div>
             
@@ -343,7 +343,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                   setActivityValue(1);
                   setActivityNote('');
                 }}
-                className="px-4 py-2 text-gray-600 hover:text-gray-900"
+                className="px-4 py-2 text-muted hover:text-[var(--text)]"
               >
                 Cancel
               </button>
@@ -376,28 +376,28 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
 
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <BarChart3 className="h-6 w-6 text-gray-600" />
+            <div className="p-2 bg-[var(--surface-muted)] rounded-lg">
+              <BarChart3 className="h-6 w-6 text-muted" />
             </div>
             <div>
-              <p className="text-sm text-gray-600">Success Rate</p>
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-sm text-muted">Success Rate</p>
+              <p className="text-2xl font-bold text-[var(--text)]">
                 {goal.progress.successRate}%
               </p>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <Clock className="h-6 w-6 text-gray-600" />
+            <div className="p-2 bg-[var(--surface-muted)] rounded-lg">
+              <Clock className="h-6 w-6 text-muted" />
             </div>
             <div>
-              <p className="text-sm text-gray-600">Last Activity</p>
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-sm text-muted">Last Activity</p>
+              <p className="text-2xl font-bold text-[var(--text)]">
                 {goal.progress.lastActivityDate 
                   ? new Date(goal.progress.lastActivityDate).toLocaleDateString()
                   : 'Never'}
@@ -406,14 +406,14 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
           </div>
         </div>
 
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <TrendingUp className="h-6 w-6 text-gray-600" />
+            <div className="p-2 bg-[var(--surface-muted)] rounded-lg">
+              <TrendingUp className="h-6 w-6 text-muted" />
             </div>
             <div>
-              <p className="text-sm text-gray-600">Projected Completion</p>
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-sm text-muted">Projected Completion</p>
+              <p className="text-2xl font-bold text-[var(--text)]">
                 {goal.progress.projectedCompletion
                   ? new Date(goal.progress.projectedCompletion).toLocaleDateString()
                   : 'TBD'}
@@ -424,8 +424,8 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
       </div>
 
       {/* Recent Activities */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Activities</h2>
+      <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+        <h2 className="text-lg font-semibold text-[var(--text)] mb-4">Recent Activities</h2>
         
         {recentActivities.length > 0 ? (
           <div className="space-y-3">
@@ -439,7 +439,7 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     activity.activityType === 'completed' ? 'bg-green-100' :
                     activity.activityType === 'progress' ? 'bg-blue-100' :
                     activity.activityType === 'skipped' ? 'bg-yellow-100' :
-                    'bg-gray-100'
+                    'bg-[var(--surface-muted)]'
                   }`}>
                     {activity.activityType === 'completed' ? (
                       <CheckCircle className="h-5 w-5 text-green-600" />
@@ -450,16 +450,16 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
                     )}
                   </div>
                   <div>
-                    <p className="font-medium text-gray-900">
+                    <p className="font-medium text-[var(--text)]">
                       {activity.value} {activity.unit}
                     </p>
                     {activity.note && (
-                      <p className="text-sm text-gray-600">{activity.note}</p>
+                      <p className="text-sm text-muted">{activity.note}</p>
                     )}
                   </div>
                 </div>
                 <div className="text-right">
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="text-sm font-medium text-[var(--text)]">
                     {new Date(activity.activityDate).toLocaleDateString()}
                   </p>
                     <p className="text-xs text-gray-500">
@@ -481,11 +481,11 @@ export const GoalDetail: React.FC<GoalDetailProps> = ({
 
       {/* Private Notes */}
       {privateNotes && (
-        <div className="bg-gray-50 rounded-lg p-6">
+        <div className="bg-[var(--surface-muted)] rounded-lg p-6">
           <h3 className="text-sm font-medium text-gray-700 mb-2 flex items-center gap-2">
             🔒 Private Notes (Encrypted)
           </h3>
-          <p className="text-gray-600 whitespace-pre-wrap">{privateNotes}</p>
+          <p className="text-muted whitespace-pre-wrap">{privateNotes}</p>
         </div>
       )}
 

--- a/frontend/src/features/goals/components/GoalList.tsx
+++ b/frontend/src/features/goals/components/GoalList.tsx
@@ -67,21 +67,21 @@ export const GoalList: React.FC<GoalListProps> = ({
           e.stopPropagation();
           setOpenMenuId(openMenuId === goal.goalId ? null : goal.goalId);
         }}
-        className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
+        className="p-1 hover:bg-[color:var(--surface-muted)] rounded-lg transition-colors"
         aria-label="Goal actions"
       >
         <MoreVertical className="h-4 w-4 text-gray-500" />
       </button>
       
       {openMenuId === goal.goalId && (
-        <div className="absolute right-0 top-8 z-10 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1">
+        <div className="absolute right-0 top-8 z-10 w-48 bg-[var(--surface)] rounded-lg shadow-lg border border-[color:var(--surface-muted)] py-1">
           <button
             onClick={(e) => {
               e.stopPropagation();
               onEditGoal(goal);
               setOpenMenuId(null);
             }}
-            className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+            className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
           >
             <Edit2 className="h-4 w-4" />
             Edit Goal
@@ -94,7 +94,7 @@ export const GoalList: React.FC<GoalListProps> = ({
                 onUpdateStatus(goal.goalId, 'paused');
                 setOpenMenuId(null);
               }}
-              className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+              className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
             >
               <Pause className="h-4 w-4" />
               Pause Goal
@@ -106,7 +106,7 @@ export const GoalList: React.FC<GoalListProps> = ({
                 onUpdateStatus(goal.goalId, 'active');
                 setOpenMenuId(null);
               }}
-              className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+              className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
             >
               <Play className="h-4 w-4" />
               Resume Goal
@@ -119,7 +119,7 @@ export const GoalList: React.FC<GoalListProps> = ({
               onUpdateStatus(goal.goalId, 'archived');
               setOpenMenuId(null);
             }}
-            className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2"
+            className="w-full px-4 py-2 text-left text-sm hover:bg-[color:var(--surface-muted)] flex items-center gap-2"
           >
             <Archive className="h-4 w-4" />
             Archive Goal
@@ -154,19 +154,19 @@ export const GoalList: React.FC<GoalListProps> = ({
         key={goal.goalId}
         onClick={() => onSelectGoal(goal)}
         className={`
-          bg-white rounded-lg border-2 p-4 cursor-pointer transition-all duration-200
-          hover:shadow-lg hover:border-gray-300
+          bg-[var(--surface)] rounded-lg border-2 p-4 cursor-pointer transition-all duration-200
+          hover:shadow-lg hover:border-[color:var(--surface-muted)]
           ${goal.status === 'paused' ? 'opacity-60' : ''}
-          ${goal.status === 'completed' ? 'border-green-300 bg-green-50' : 'border-gray-200'}
+          ${goal.status === 'completed' ? 'border-green-300 bg-green-50' : 'border-[color:var(--surface-muted)]'}
         `}
       >
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-start gap-3 flex-1">
             <span className="text-2xl">{getGoalIcon(goal.goalPattern)}</span>
             <div className="flex-1">
-              <h3 className="font-semibold text-gray-900 mb-1">{goal.title}</h3>
+              <h3 className="font-semibold text-[var(--text)] mb-1">{goal.title}</h3>
               {goal.description && (
-                <p className="text-sm text-gray-600 line-clamp-1">{goal.description}</p>
+                <p className="text-sm text-muted line-clamp-1">{goal.description}</p>
               )}
               <div className="flex items-center gap-2 mt-2">
                 <span
@@ -201,7 +201,7 @@ export const GoalList: React.FC<GoalListProps> = ({
         <div className="mt-3 pt-3 border-t border-gray-100">
           {goal.goalPattern === 'recurring' && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">
+              <span className="text-muted">
                 {goal.progress.currentPeriodValue || 0} / {goal.target.value} {goal.target.unit} this {goal.target.period}
               </span>
               <span className="font-medium" style={{ color }}>
@@ -212,7 +212,7 @@ export const GoalList: React.FC<GoalListProps> = ({
           
           {goal.goalPattern === 'milestone' && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">
+              <span className="text-muted">
                 {goal.progress.totalAccumulated || 0} / {goal.target.value} {goal.target.unit}
               </span>
               <span className="font-medium" style={{ color }}>
@@ -223,7 +223,7 @@ export const GoalList: React.FC<GoalListProps> = ({
           
           {goal.goalPattern === 'target' && goal.target.targetDate && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">
+              <span className="text-muted">
                 Target: {new Date(goal.target.targetDate).toLocaleDateString()}
               </span>
               <span className="font-medium" style={{ color }}>
@@ -239,7 +239,7 @@ export const GoalList: React.FC<GoalListProps> = ({
                 size="sm"
                 color={color}
               />
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted">
                 Best: {goal.progress.longestStreak || 0} days
               </span>
             </div>
@@ -247,7 +247,7 @@ export const GoalList: React.FC<GoalListProps> = ({
           
           {goal.goalPattern === 'limit' && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">
+              <span className="text-muted">
                 Avg: {goal.progress.averageValue?.toFixed(1)} {goal.target.unit}/{goal.target.period}
               </span>
               <span 
@@ -269,10 +269,10 @@ export const GoalList: React.FC<GoalListProps> = ({
     <div className={`space-y-6 ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">Your Goals</h2>
+        <h2 className="text-2xl font-bold text-[var(--text)]">Your Goals</h2>
         <button
           onClick={onCreateGoal}
-          className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+          className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]"
         >
           <Plus className="h-5 w-5" />
           New Goal
@@ -280,7 +280,7 @@ export const GoalList: React.FC<GoalListProps> = ({
       </div>
 
       {/* Filters */}
-      <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+      <div className="bg-[var(--surface-muted)] rounded-lg p-4 space-y-4">
         <div className="flex items-center gap-4">
           <div className="flex-1 relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
@@ -289,7 +289,7 @@ export const GoalList: React.FC<GoalListProps> = ({
               placeholder="Search goals..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              className="w-full pl-10 pr-4 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
             />
           </div>
           
@@ -308,7 +308,7 @@ export const GoalList: React.FC<GoalListProps> = ({
           <select
             value={selectedCategory}
             onChange={(e) => setSelectedCategory(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            className="px-3 py-1.5 border border-[color:var(--surface-muted)] rounded-lg text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
           >
             <option value="all">All Categories</option>
             {GOAL_CATEGORIES.map(cat => (
@@ -321,7 +321,7 @@ export const GoalList: React.FC<GoalListProps> = ({
           <select
             value={selectedPattern}
             onChange={(e) => setSelectedPattern(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            className="px-3 py-1.5 border border-[color:var(--surface-muted)] rounded-lg text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
           >
             <option value="all">All Patterns</option>
             <option value="recurring">🔄 Recurring</option>
@@ -339,8 +339,8 @@ export const GoalList: React.FC<GoalListProps> = ({
           <div className="text-gray-400 mb-4">
             <Target className="h-12 w-12 mx-auto" />
           </div>
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No goals found</h3>
-          <p className="text-gray-600 mb-4">
+          <h3 className="text-lg font-medium text-[var(--text)] mb-2">No goals found</h3>
+          <p className="text-muted mb-4">
             {searchTerm || selectedCategory !== 'all' || selectedPattern !== 'all'
               ? 'Try adjusting your filters'
               : 'Create your first goal to get started'}

--- a/frontend/src/features/goals/components/GoalProgress/ActivityHistory.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/ActivityHistory.tsx
@@ -34,8 +34,8 @@ const ActivityHistory: React.FC<ActivityHistoryProps> = ({ goalId, className = '
   };
 
   return (
-    <div className={`bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4 ${className}`}>
-      <h2 className="text-lg font-semibold text-gray-900">Activity History</h2>
+    <div className={`bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6 space-y-4 ${className}`}>
+      <h2 className="text-lg font-semibold text-[var(--text)]">Activity History</h2>
       {isLoading ? (
         <p className="text-center text-gray-500">Loading...</p>
       ) : error ? (
@@ -58,22 +58,22 @@ const ActivityHistory: React.FC<ActivityHistoryProps> = ({ goalId, className = '
                       ? 'bg-blue-100'
                       : activity.activityType === 'skipped'
                       ? 'bg-yellow-100'
-                      : 'bg-gray-100'
+                      : 'bg-[var(--surface-muted)]'
                   }`}
                 >
                   {renderIcon(activity.activityType)}
                 </div>
                 <div>
-                  <p className="font-medium text-gray-900">
+                  <p className="font-medium text-[var(--text)]">
                     {activity.value} {activity.unit}
                   </p>
                   {activity.note && (
-                    <p className="text-sm text-gray-600">{activity.note}</p>
+                    <p className="text-sm text-muted">{activity.note}</p>
                   )}
                 </div>
               </div>
               <div className="text-right">
-                <p className="text-sm font-medium text-gray-900">
+                <p className="text-sm font-medium text-[var(--text)]">
                   {new Date(activity.activityDate).toLocaleDateString()}
                 </p>
                 {activity.context?.timeOfDay && (
@@ -95,7 +95,7 @@ const ActivityHistory: React.FC<ActivityHistoryProps> = ({ goalId, className = '
         >
           Previous
         </button>
-        <span className="text-sm text-gray-600">
+        <span className="text-sm text-muted">
           Page {page} of {pages}
         </span>
         <button

--- a/frontend/src/features/goals/components/GoalProgress/MilestoneChart.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/MilestoneChart.tsx
@@ -65,8 +65,8 @@ export const MilestoneChart: React.FC<MilestoneChartProps> = ({
   const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: TooltipPayload[] }) => {
     if (active && payload && payload[0]) {
       return (
-        <div className="bg-white p-3 rounded-lg shadow-lg border border-gray-200">
-          <p className="text-sm font-medium text-gray-900">{payload[0].payload.date}</p>
+        <div className="bg-[var(--surface)] p-3 rounded-lg shadow-lg border border-[color:var(--surface-muted)]">
+          <p className="text-sm font-medium text-[var(--text)]">{payload[0].payload.date}</p>
           <p className="text-sm" style={{ color }}>
             {payload[0].value.toLocaleString()} {unit}
           </p>
@@ -109,12 +109,12 @@ export const MilestoneChart: React.FC<MilestoneChartProps> = ({
   };
 
   return (
-    <div className={`bg-white rounded-lg p-4 ${className}`}>
+    <div className={`bg-[var(--surface)] rounded-lg p-4 ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Progress Over Time</h3>
-          <p className="text-sm text-gray-600">
+          <h3 className="text-lg font-semibold text-[var(--text)]">Progress Over Time</h3>
+          <p className="text-sm text-muted">
             {currentValue.toLocaleString()} / {targetValue.toLocaleString()} {unit}
           </p>
         </div>
@@ -213,7 +213,7 @@ export const MilestoneChart: React.FC<MilestoneChartProps> = ({
       
       {/* Summary */}
       <div className="mt-4 flex items-center justify-between text-sm">
-        <div className="flex items-center gap-2 text-gray-600">
+        <div className="flex items-center gap-2 text-muted">
           <Calendar className="h-4 w-4" />
           <span>Started {data[0].date.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}</span>
         </div>

--- a/frontend/src/features/goals/components/GoalProgress/ProgressCharts.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/ProgressCharts.tsx
@@ -316,13 +316,13 @@ const ProgressCharts: React.FC<ProgressChartsProps> = ({
   return (
     <div className={`space-y-6 ${className}`}>
       {/* Chart Controls */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
-          <h2 className="text-lg font-semibold text-gray-900">Progress Analytics</h2>
+          <h2 className="text-lg font-semibold text-[var(--text)]">Progress Analytics</h2>
           
           <div className="flex flex-wrap items-center gap-3">
             {/* Chart Type Selector */}
-            <div className="flex bg-gray-100 rounded-lg p-1">
+            <div className="flex bg-[var(--surface-muted)] rounded-lg p-1">
               {[
                 { type: 'line' as ChartType, icon: Activity },
                 { type: 'bar' as ChartType, icon: BarChart3 },
@@ -335,8 +335,8 @@ const ProgressCharts: React.FC<ProgressChartsProps> = ({
                   onClick={() => setChartType(type)}
                   className={`p-2 rounded transition-all ${
                     chartType === type
-                      ? 'bg-white shadow-sm text-gray-900'
-                      : 'text-gray-600 hover:text-gray-900'
+                      ? 'bg-[var(--surface)] shadow-sm text-[var(--text)]'
+                      : 'text-muted hover:text-[var(--text)]'
                   }`}
                   title={`${type} chart`}
                 >
@@ -350,7 +350,7 @@ const ProgressCharts: React.FC<ProgressChartsProps> = ({
               <select
                 value={timeRange}
                 onChange={(e) => setTimeRange(e.target.value as TimeRange)}
-                className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                className="px-3 py-1.5 text-sm border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 <option value="7d">Last 7 days</option>
                 <option value="30d">Last 30 days</option>
@@ -369,7 +369,7 @@ const ProgressCharts: React.FC<ProgressChartsProps> = ({
                   onChange={(e) => setShowTarget(e.target.checked)}
                   className="rounded text-primary-600 focus:ring-primary-500"
                 />
-                <span className="text-gray-600">Show target</span>
+                <span className="text-muted">Show target</span>
               </label>
             )}
           </div>
@@ -393,41 +393,41 @@ const ProgressCharts: React.FC<ProgressChartsProps> = ({
 
       {/* Statistics Summary */}
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <p className="text-sm text-gray-600 mb-1">Total</p>
-          <p className="text-2xl font-bold text-gray-900">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
+          <p className="text-sm text-muted mb-1">Total</p>
+          <p className="text-2xl font-bold text-[var(--text)]">
             {stats.total.toFixed(1)} <span className="text-sm font-normal">{goal.target.unit}</span>
           </p>
         </div>
         
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <p className="text-sm text-gray-600 mb-1">Average</p>
-          <p className="text-2xl font-bold text-gray-900">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
+          <p className="text-sm text-muted mb-1">Average</p>
+          <p className="text-2xl font-bold text-[var(--text)]">
             {stats.average.toFixed(1)} <span className="text-sm font-normal">{goal.target.unit}</span>
           </p>
         </div>
         
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <p className="text-sm text-gray-600 mb-1">Best</p>
-          <p className="text-2xl font-bold text-gray-900">
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
+          <p className="text-sm text-muted mb-1">Best</p>
+          <p className="text-2xl font-bold text-[var(--text)]">
             {stats.max.toFixed(1)} <span className="text-sm font-normal">{goal.target.unit}</span>
           </p>
         </div>
         
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <p className="text-sm text-gray-600 mb-1">Consistency</p>
-          <p className="text-2xl font-bold text-gray-900">{stats.consistency}%</p>
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
+          <p className="text-sm text-muted mb-1">Consistency</p>
+          <p className="text-2xl font-bold text-[var(--text)]">{stats.consistency}%</p>
         </div>
         
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <p className="text-sm text-gray-600 mb-1">Trend</p>
+        <div className="bg-[var(--surface)] rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-4">
+          <p className="text-sm text-muted mb-1">Trend</p>
           <div className="flex items-center gap-2">
             {goal.progress.trend === 'improving' ? (
               <TrendingUp className="h-6 w-6 text-green-600" />
             ) : goal.progress.trend === 'declining' ? (
               <TrendingDown className="h-6 w-6 text-red-600" />
             ) : (
-              <Activity className="h-6 w-6 text-gray-600" />
+              <Activity className="h-6 w-6 text-muted" />
             )}
             <span className="text-lg font-semibold capitalize">{goal.progress.trend}</span>
           </div>

--- a/frontend/src/features/goals/components/GoalProgress/StreakCalendar.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/StreakCalendar.tsx
@@ -67,9 +67,9 @@ export const StreakCalendar: React.FC<StreakCalendarProps> = ({
       case 'skipped':
         return 'bg-gray-200 text-gray-500';
       case 'future':
-        return 'bg-gray-50 text-gray-300 cursor-not-allowed';
+        return 'bg-[var(--surface-muted)] text-gray-300 cursor-not-allowed';
       default:
-        return 'bg-white text-gray-400 border border-gray-200';
+        return 'bg-[var(--surface)] text-gray-400 border border-[color:var(--surface-muted)]';
     }
   };
   
@@ -133,11 +133,11 @@ export const StreakCalendar: React.FC<StreakCalendarProps> = ({
   }
   
   return (
-    <div className={`bg-white rounded-lg p-6 ${className}`}>
+    <div className={`bg-[var(--surface)] rounded-lg p-6 ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">Streak Calendar</h3>
+          <h3 className="text-lg font-semibold text-[var(--text)]">Streak Calendar</h3>
           <div className="flex items-center gap-4 mt-1">
             <div className="flex items-center gap-2">
               <Flame className="h-5 w-5" style={{ color }} />
@@ -155,20 +155,20 @@ export const StreakCalendar: React.FC<StreakCalendarProps> = ({
         <div className="flex items-center gap-2">
           <button
             onClick={handlePrevMonth}
-            className="p-1 hover:bg-gray-100 rounded"
+            className="p-1 hover:bg-[color:var(--surface-muted)] rounded"
             aria-label="Previous month"
           >
-            <ChevronLeft className="h-5 w-5 text-gray-600" />
+            <ChevronLeft className="h-5 w-5 text-muted" />
           </button>
           <span className="text-sm font-medium text-gray-700 min-w-[120px] text-center">
             {monthNames[month.getMonth()]} {month.getFullYear()}
           </span>
           <button
             onClick={handleNextMonth}
-            className="p-1 hover:bg-gray-100 rounded"
+            className="p-1 hover:bg-[color:var(--surface-muted)] rounded"
             aria-label="Next month"
           >
-            <ChevronRight className="h-5 w-5 text-gray-600" />
+            <ChevronRight className="h-5 w-5 text-muted" />
           </button>
         </div>
       </div>
@@ -194,15 +194,15 @@ export const StreakCalendar: React.FC<StreakCalendarProps> = ({
             className="h-4 w-4 rounded"
             style={{ backgroundColor: color }}
           />
-          <span className="text-gray-600">Completed</span>
+          <span className="text-muted">Completed</span>
         </div>
         <div className="flex items-center gap-2">
           <div className="h-4 w-4 rounded bg-gray-200" />
-          <span className="text-gray-600">Skipped</span>
+          <span className="text-muted">Skipped</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="h-4 w-4 rounded border border-gray-200 bg-white" />
-          <span className="text-gray-600">Missed</span>
+          <div className="h-4 w-4 rounded border border-[color:var(--surface-muted)] bg-[var(--surface)]" />
+          <span className="text-muted">Missed</span>
         </div>
       </div>
     </div>

--- a/frontend/src/features/goals/components/GoalProgress/TrendLine.tsx
+++ b/frontend/src/features/goals/components/GoalProgress/TrendLine.tsx
@@ -145,8 +145,8 @@ export const TrendLine: React.FC<TrendLineProps> = ({
     if (active && payload && payload.length > 0) {
       const data = payload[0].payload;
       return (
-        <div className="bg-white p-3 rounded-lg shadow-lg border border-gray-200">
-          <p className="text-sm font-medium text-gray-900">{data.date}</p>
+        <div className="bg-[var(--surface)] p-3 rounded-lg shadow-lg border border-[color:var(--surface-muted)]">
+          <p className="text-sm font-medium text-[var(--text)]">{data.date}</p>
           {payload.map((entry, index) => (
             <p key={index} className="text-sm" style={{ color: entry.stroke }}>
               {entry.name}: {entry.value?.toFixed(1)} {unit}
@@ -177,12 +177,12 @@ export const TrendLine: React.FC<TrendLineProps> = ({
   };
 
   return (
-    <div className={`bg-white rounded-lg p-6 ${className}`}>
+    <div className={`bg-[var(--surface)] rounded-lg p-6 ${className}`}>
       {/* Header */}
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900 mb-1">Progress Trend</h3>
-          <p className="text-sm text-gray-600">
+          <h3 className="text-lg font-semibold text-[var(--text)] mb-1">Progress Trend</h3>
+          <p className="text-sm text-muted">
             {direction === 'increase' ? 'Increasing' : 'Decreasing'} from {startValue} to {targetValue} {unit}
           </p>
         </div>
@@ -208,7 +208,7 @@ export const TrendLine: React.FC<TrendLineProps> = ({
         
         <div className="text-center">
           <p className="text-sm text-gray-500 mb-1">Target</p>
-          <p className="text-xl font-bold text-gray-900">
+          <p className="text-xl font-bold text-[var(--text)]">
             {targetValue} {unit}
           </p>
           <p className="text-xs text-gray-500 mt-1">
@@ -326,28 +326,28 @@ export const TrendLine: React.FC<TrendLineProps> = ({
         
         <div className="grid grid-cols-2 gap-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <Calendar className="h-5 w-5 text-gray-600" />
+            <div className="p-2 bg-[var(--surface-muted)] rounded-lg">
+              <Calendar className="h-5 w-5 text-muted" />
             </div>
             <div>
               <p className="text-xs text-gray-500">Time Elapsed</p>
-              <p className="text-sm font-medium text-gray-900">
+              <p className="text-sm font-medium text-[var(--text)]">
                 {daysElapsed} / {daysTotal} days ({Math.round((daysElapsed / daysTotal) * 100)}%)
               </p>
             </div>
           </div>
           
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
+            <div className="p-2 bg-[var(--surface-muted)] rounded-lg">
               {direction === 'increase' ? (
-                <TrendingUp className="h-5 w-5 text-gray-600" />
+                <TrendingUp className="h-5 w-5 text-muted" />
               ) : (
-                <TrendingDown className="h-5 w-5 text-gray-600" />
+                <TrendingDown className="h-5 w-5 text-muted" />
               )}
             </div>
             <div>
               <p className="text-xs text-gray-500">Average Daily Change</p>
-              <p className="text-sm font-medium text-gray-900">
+              <p className="text-sm font-medium text-[var(--text)]">
                 {averageChangePerDay >= 0 ? '+' : ''}{averageChangePerDay.toFixed(2)} {unit}/day
               </p>
             </div>

--- a/frontend/src/features/goals/components/UpdateGoalForm.tsx
+++ b/frontend/src/features/goals/components/UpdateGoalForm.tsx
@@ -92,12 +92,12 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="sticky top-0 bg-white border-b border-gray-200 p-6 flex items-center justify-between">
-          <h2 className="text-2xl font-bold text-gray-900">Edit Goal</h2>
+      <div className="bg-[var(--surface)] rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-[var(--surface)] border-b border-[color:var(--surface-muted)] p-6 flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-[var(--text)]">Edit Goal</h2>
           <button
             onClick={onCancel}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-[color:var(--surface-muted)] rounded-lg transition-colors"
             aria-label="Close"
           >
             <X className="h-5 w-5 text-gray-500" />
@@ -113,7 +113,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
 
           {/* Basic Information */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">Basic Information</h3>
+            <h3 className="text-lg font-semibold text-[var(--text)]">Basic Information</h3>
             
             <div>
               <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
@@ -141,7 +141,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                 placeholder="Add more details about your goal..."
                 rows={3}
                 maxLength={1000}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               />
             </div>
 
@@ -154,7 +154,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                   id="category"
                   value={formData.category || ''}
                   onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
                   {GOAL_CATEGORIES.map((cat) => (
                     <option key={cat.value} value={cat.value}>
@@ -172,7 +172,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                   id="status"
                   value={formData.status || 'active'}
                   onChange={(e) => setFormData({ ...formData, status: e.target.value as 'active' | 'paused' })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
                   <option value="active">Active</option>
                   <option value="paused">Paused</option>
@@ -183,7 +183,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
 
           {/* Appearance */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">Appearance</h3>
+            <h3 className="text-lg font-semibold text-[var(--text)]">Appearance</h3>
             
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -199,7 +199,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                       p-3 text-2xl rounded-lg border-2 transition-all
                       ${formData.icon === icon
                         ? 'border-primary-500 bg-primary-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                        : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
                       }
                     `}
                   >
@@ -221,7 +221,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                   onChange={(e) => setFormData({ ...formData, color: e.target.value })}
                   className="h-10 w-20"
                 />
-                <span className="text-sm text-gray-600">{formData.color || '#6366f1'}</span>
+                <span className="text-sm text-muted">{formData.color || '#6366f1'}</span>
               </div>
             </div>
           </div>
@@ -229,7 +229,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
           {/* Target Value (only for certain goal patterns) */}
           {['target', 'milestone', 'limit'].includes(goal.goalPattern) && (
             <div className="space-y-4">
-              <h3 className="text-lg font-semibold text-gray-900">Target</h3>
+              <h3 className="text-lg font-semibold text-[var(--text)]">Target</h3>
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
@@ -272,7 +272,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
 
           {/* Privacy */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">Privacy</h3>
+            <h3 className="text-lg font-semibold text-[var(--text)]">Privacy</h3>
             
             <div>
               <label htmlFor="visibility" className="block text-sm font-medium text-gray-700 mb-1">
@@ -282,7 +282,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
                 id="visibility"
                 value={formData.visibility || 'private'}
                 onChange={(e) => setFormData({ ...formData, visibility: e.target.value as 'private' | 'friends' | 'public' })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 <option value="private">Private (Only you)</option>
                 <option value="friends">Friends</option>
@@ -292,7 +292,7 @@ const UpdateGoalForm: React.FC<UpdateGoalFormProps> = ({
           </div>
 
           {/* Form Actions */}
-          <div className="flex justify-end gap-3 pt-6 border-t border-gray-200">
+          <div className="flex justify-end gap-3 pt-6 border-t border-[color:var(--surface-muted)]">
             <Button
               type="button"
               variant="ghost"

--- a/frontend/src/features/goals/components/creation/BasicInfoStep.tsx
+++ b/frontend/src/features/goals/components/creation/BasicInfoStep.tsx
@@ -54,8 +54,8 @@ const BasicInfoStep: React.FC<BasicInfoStepProps> = ({ initialValues, onComplete
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Basic Information</h3>
-        <p className="text-sm text-gray-600 mb-6">
+        <h3 className="text-lg font-medium text-[var(--text)] mb-4">Basic Information</h3>
+        <p className="text-sm text-muted mb-6">
           Give your goal a clear name and choose a category to help organize it.
         </p>
       </div>
@@ -78,7 +78,7 @@ const BasicInfoStep: React.FC<BasicInfoStepProps> = ({ initialValues, onComplete
         <textarea
           {...register('description')}
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-primary-500 focus:border-primary-500"
           placeholder="Add more details about your goal..."
         />
         {errors.description && (
@@ -106,7 +106,7 @@ const BasicInfoStep: React.FC<BasicInfoStepProps> = ({ initialValues, onComplete
                 ${
                   selectedCategory === category.value
                     ? 'border-primary-500 bg-primary-50'
-                    : 'border-gray-200 hover:border-gray-300'
+                    : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
                 }
               `}
             >
@@ -133,7 +133,7 @@ const BasicInfoStep: React.FC<BasicInfoStepProps> = ({ initialValues, onComplete
               onClick={() => setValue('color', color)}
               className={`
                 w-10 h-10 rounded-full border-2 transition-all
-                ${selectedColor === color ? 'border-gray-900 scale-110' : 'border-gray-300'}
+                ${selectedColor === color ? 'border-gray-900 scale-110' : 'border-[color:var(--surface-muted)]'}
               `}
               style={{ backgroundColor: color }}
               aria-label={`Select ${color} color`}

--- a/frontend/src/features/goals/components/creation/GoalWizard.tsx
+++ b/frontend/src/features/goals/components/creation/GoalWizard.tsx
@@ -176,8 +176,8 @@ const GoalWizard: React.FC = () => {
             <div className="inline-flex items-center justify-center w-16 h-16 bg-primary-100 rounded-full mb-4">
               <Sparkles className="h-8 w-8 text-primary-600" />
             </div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">Create Your Goal</h1>
-            <p className="text-lg text-gray-600">Choose a pattern that fits your journey</p>
+            <h1 className="text-3xl font-bold text-[var(--text)] mb-2">Create Your Goal</h1>
+            <p className="text-lg text-muted">Choose a pattern that fits your journey</p>
           </div>
           <PatternSelector
             onSelect={handlePatternSelect}
@@ -215,7 +215,7 @@ const GoalWizard: React.FC = () => {
       <div className="mb-6">
         <button
           onClick={selectedPattern ? handleBack : handleCancel}
-          className="inline-flex items-center text-gray-600 hover:text-gray-900 transition-colors"
+          className="inline-flex items-center text-muted hover:text-[var(--text)] transition-colors"
           disabled={isSubmitting}
         >
           <ArrowLeft className="h-5 w-5 mr-2" />
@@ -224,7 +224,7 @@ const GoalWizard: React.FC = () => {
       </div>
 
       {/* Form Content */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200">
+      <div className="bg-[var(--surface)] rounded-xl shadow-sm border border-[color:var(--surface-muted)]">
         <div className="p-6 sm:p-8">
           {renderForm()}
         </div>
@@ -233,7 +233,7 @@ const GoalWizard: React.FC = () => {
       {/* Loading Overlay */}
       {isSubmitting && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 flex flex-col items-center">
+          <div className="bg-[var(--surface)] rounded-lg p-6 flex flex-col items-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mb-4"></div>
             <p className="text-gray-700 font-medium">Creating your goal...</p>
           </div>

--- a/frontend/src/features/goals/components/creation/MotivationStep.tsx
+++ b/frontend/src/features/goals/components/creation/MotivationStep.tsx
@@ -23,8 +23,8 @@ const MotivationStep: React.FC<MotivationStepProps> = ({ initialValues, onComple
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Your Motivation</h3>
-        <p className="text-sm text-gray-600">
+        <h3 className="text-lg font-medium text-[var(--text)] mb-4">Your Motivation</h3>
+        <p className="text-sm text-muted">
           Understanding why this goal matters will help you stay committed.
         </p>
       </div>
@@ -37,7 +37,7 @@ const MotivationStep: React.FC<MotivationStepProps> = ({ initialValues, onComple
           value={context.motivation}
           onChange={(e) => setContext({ ...context, motivation: e.target.value })}
           rows={3}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
         />
       </div>
 
@@ -68,7 +68,7 @@ const MotivationStep: React.FC<MotivationStepProps> = ({ initialValues, onComple
           type="text"
           value={context.obstacles?.join(', ') || ''}
           onChange={(e) => setContext({ ...context, obstacles: e.target.value ? e.target.value.split(/,\s*/) : [] })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
         />
       </div>
 
@@ -80,7 +80,7 @@ const MotivationStep: React.FC<MotivationStepProps> = ({ initialValues, onComple
           type="text"
           value={context.successFactors?.join(', ') || ''}
           onChange={(e) => setContext({ ...context, successFactors: e.target.value ? e.target.value.split(/,\s*/) : [] })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
         />
       </div>
 

--- a/frontend/src/features/goals/components/creation/PatternSelector.tsx
+++ b/frontend/src/features/goals/components/creation/PatternSelector.tsx
@@ -11,8 +11,8 @@ const PatternSelector: React.FC<PatternSelectorProps> = ({ onSelect, selectedPat
   return (
     <div className="space-y-4">
       <div className="text-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900">What kind of goal do you want to set?</h2>
-        <p className="mt-2 text-gray-600">Choose the pattern that best fits what you want to achieve</p>
+        <h2 className="text-2xl font-bold text-[var(--text)]">What kind of goal do you want to set?</h2>
+        <p className="mt-2 text-muted">Choose the pattern that best fits what you want to achieve</p>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -22,11 +22,11 @@ const PatternSelector: React.FC<PatternSelectorProps> = ({ onSelect, selectedPat
             onClick={() => onSelect(pattern.id)}
             className={`
               relative p-6 rounded-lg border-2 transition-all text-left
-              hover:shadow-lg hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2
+              hover:shadow-lg hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[color:var(--bg)]
               ${
                 selectedPattern === pattern.id
                   ? `${pattern.borderColor} ${pattern.bgColor} ring-2 ring-offset-2`
-                  : 'border-gray-200 hover:border-gray-300 bg-white'
+                  : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)] bg-[var(--surface)]'
               }
             `}
             style={{
@@ -38,12 +38,12 @@ const PatternSelector: React.FC<PatternSelectorProps> = ({ onSelect, selectedPat
             <div className="text-4xl mb-3">{pattern.icon}</div>
 
             {/* Pattern Title */}
-            <h3 className="text-lg font-semibold text-gray-900 mb-1">
+            <h3 className="text-lg font-semibold text-[var(--text)] mb-1">
               {pattern.title}
             </h3>
 
             {/* Pattern Description */}
-            <p className="text-sm text-gray-600 mb-3">
+            <p className="text-sm text-muted mb-3">
               {pattern.description}
             </p>
 

--- a/frontend/src/features/goals/components/creation/ReviewStep.tsx
+++ b/frontend/src/features/goals/components/creation/ReviewStep.tsx
@@ -16,14 +16,14 @@ const ReviewStep: React.FC<ReviewStepProps> = ({ goalData, onSubmit, isSubmittin
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Review Your Goal</h3>
-        <p className="text-sm text-gray-600">
+        <h3 className="text-lg font-medium text-[var(--text)] mb-4">Review Your Goal</h3>
+        <p className="text-sm text-muted">
           Make sure everything looks good before creating your goal.
         </p>
       </div>
 
       {/* Goal Summary */}
-      <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+      <div className="bg-[var(--surface-muted)] rounded-lg p-6 space-y-4">
         {/* Pattern Badge */}
         <div className="flex items-center space-x-3">
           <span className="text-2xl">{pattern.icon}</span>
@@ -37,9 +37,9 @@ const ReviewStep: React.FC<ReviewStepProps> = ({ goalData, onSubmit, isSubmittin
 
         {/* Title & Description */}
         <div>
-          <h4 className="text-xl font-semibold text-gray-900">{goalData.title}</h4>
+          <h4 className="text-xl font-semibold text-[var(--text)]">{goalData.title}</h4>
           {goalData.description && (
-            <p className="mt-1 text-gray-600">{goalData.description}</p>
+            <p className="mt-1 text-muted">{goalData.description}</p>
           )}
         </div>
 

--- a/frontend/src/features/goals/components/creation/ScheduleStep.tsx
+++ b/frontend/src/features/goals/components/creation/ScheduleStep.tsx
@@ -52,8 +52,8 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Schedule Your Goal</h3>
-        <p className="text-sm text-gray-600">
+        <h3 className="text-lg font-medium text-[var(--text)] mb-4">Schedule Your Goal</h3>
+        <p className="text-sm text-muted">
           When and how often do you want to work on this goal?
         </p>
       </div>
@@ -73,7 +73,7 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
                   frequency: e.target.value as GoalSchedule['frequency'],
                 })
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
             >
               <option value="daily">Daily</option>
               <option value="weekly">Weekly</option>
@@ -93,7 +93,7 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
                     key={d.value}
                     type="button"
                     onClick={() => handleDayToggle(d.value)}
-                    className={`w-8 h-8 rounded-full text-sm transition-colors ${schedule.daysOfWeek?.includes(d.value) ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+                    className={`w-8 h-8 rounded-full text-sm transition-colors ${schedule.daysOfWeek?.includes(d.value) ? 'bg-primary-600 text-white' : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'}`}
                     aria-label={d.label}
                   >
                     {d.label.charAt(0)}
@@ -112,7 +112,7 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
               type="time"
               value={schedule.preferredTimes?.[0] || ''}
               onChange={(e) => setSchedule({ ...schedule, preferredTimes: e.target.value ? [e.target.value] : [] })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+              className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
             />
           </div>
         </>
@@ -131,7 +131,7 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
               checkInFrequency: e.target.value as GoalSchedule['checkInFrequency'],
             })
           }
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+          className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
         >
           <option value="daily">Daily</option>
           <option value="weekly">Weekly</option>
@@ -150,7 +150,7 @@ const ScheduleStep: React.FC<ScheduleStepProps> = ({ pattern, initialValues, onC
             min="0"
             value={schedule.allowSkipDays ?? 0}
             onChange={(e) => setSchedule({ ...schedule, allowSkipDays: parseInt(e.target.value) || 0 })}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+            className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
           />
         </div>
         <div className="flex items-center gap-2 mt-6 md:mt-0">

--- a/frontend/src/features/goals/components/creation/TargetStep.tsx
+++ b/frontend/src/features/goals/components/creation/TargetStep.tsx
@@ -66,7 +66,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                   value={target.value}
                   onChange={(e) => updateTarget({ value: parseInt(e.target.value) || 1 })}
                   min={1}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                  className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
                   required
                 />
               </div>
@@ -77,7 +77,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 <select
                   value={target.period}
                   onChange={(e) => updateTarget({ period: e.target.value as 'day' | 'week' | 'month' | 'quarter' | 'year' })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                  className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
                 >
                   <option value="day">Day</option>
                   <option value="week">Week</option>
@@ -85,7 +85,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 </select>
               </div>
             </div>
-            <p className="text-sm text-gray-600 mt-2">
+            <p className="text-sm text-muted mt-2">
               Example: Exercise 3 times per week, Read 20 pages per day
             </p>
           </>
@@ -103,7 +103,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 value={target.value}
                 onChange={(e) => updateTarget({ value: parseInt(e.target.value) || 1 })}
                 min={1}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
                 required
               />
             </div>
@@ -116,10 +116,10 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 value={target.targetDate ? target.targetDate.split('T')[0] : ''}
                 onChange={(e) => updateTarget({ targetDate: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
                 min={new Date().toISOString().split('T')[0]}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
               />
             </div>
-            <p className="text-sm text-gray-600 mt-2">
+            <p className="text-sm text-muted mt-2">
               Example: Read 52 books this year, Save $10,000 by December
             </p>
           </>
@@ -137,11 +137,11 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 value={target.value}
                 onChange={(e) => updateTarget({ value: parseInt(e.target.value) || 1 })}
                 min={1}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
                 required
               />
             </div>
-            <p className="text-sm text-gray-600 mt-2">
+            <p className="text-sm text-muted mt-2">
               Example: Meditate for 30 consecutive days, Write daily for 100 days
             </p>
           </>
@@ -157,7 +157,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
               <input
                 type="text"
                 placeholder="e.g., Complete marathon, Finish online course"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
               />
             </div>
             <div>
@@ -169,7 +169,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 value={target.targetDate ? target.targetDate.split('T')[0] : ''}
                 onChange={(e) => updateTarget({ targetDate: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
                 min={new Date().toISOString().split('T')[0]}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
               />
             </div>
           </>
@@ -187,7 +187,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 value={target.value}
                 onChange={(e) => updateTarget({ value: parseInt(e.target.value) || 1 })}
                 min={0}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
                 required
               />
             </div>
@@ -198,14 +198,14 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
               <select
                 value={target.period}
                 onChange={(e) => updateTarget({ period: e.target.value as 'day' | 'week' | 'month' | 'quarter' | 'year' })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+                className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
               >
                 <option value="day">Day</option>
                 <option value="week">Week</option>
                 <option value="month">Month</option>
               </select>
             </div>
-            <p className="text-sm text-gray-600 mt-2">
+            <p className="text-sm text-muted mt-2">
               Example: Maximum 2 hours social media per day, Spend less than $50 per week on dining out
             </p>
           </>
@@ -223,8 +223,8 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
           <PatternIcon className="h-6 w-6 text-primary-600" />
         </div>
         <div>
-          <h3 className="text-lg font-medium text-gray-900">Set Your Target</h3>
-          <p className="text-sm text-gray-600">
+          <h3 className="text-lg font-medium text-[var(--text)]">Set Your Target</h3>
+          <p className="text-sm text-muted">
             Define what you want to achieve with this {pattern} goal
           </p>
         </div>
@@ -246,7 +246,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
                 unit: METRIC_UNITS[newType][0] || 'times' 
               });
             }}
-            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+            className="px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
           >
             <option value="count">Count</option>
             <option value="duration">Duration</option>
@@ -256,7 +256,7 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
           <select
             value={target.unit}
             onChange={(e) => updateTarget({ unit: e.target.value })}
-            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+            className="px-3 py-2 border border-[color:var(--surface-muted)] rounded-lg focus:ring-2 focus:ring-primary-500"
           >
             {availableUnits.map(unit => (
               <option key={unit} value={unit}>{unit}</option>
@@ -266,13 +266,13 @@ const TargetStep: React.FC<TargetStepProps> = ({ pattern, initialValues, onCompl
       </div>
 
       {/* Pattern-specific fields */}
-      <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+      <div className="bg-[var(--surface-muted)] rounded-lg p-4 space-y-4">
         {renderPatternSpecificFields()}
       </div>
 
       {/* Preview */}
       <div className="bg-primary-50 rounded-lg p-4">
-        <h4 className="font-medium text-gray-900 mb-2">Goal Summary</h4>
+        <h4 className="font-medium text-[var(--text)] mb-2">Goal Summary</h4>
         <div className="text-sm text-gray-700">
           {pattern === 'recurring' && (
             <p>Complete {target.value} {target.unit} per {target.period}</p>

--- a/frontend/src/features/goals/components/display/EmptyState.tsx
+++ b/frontend/src/features/goals/components/display/EmptyState.tsx
@@ -24,10 +24,10 @@ const EmptyState: React.FC = () => {
         </div>
 
         {/* Title */}
-        <h3 className="text-lg font-medium text-gray-900 mb-2">No goals yet</h3>
+        <h3 className="text-lg font-medium text-[var(--text)] mb-2">No goals yet</h3>
 
         {/* Description */}
-        <p className="text-gray-600 mb-6">
+        <p className="text-muted mb-6">
           Start your journey by creating your first goal. Whether it's building a new habit, reaching
           a milestone, or setting limits, we're here to help you succeed.
         </p>
@@ -46,29 +46,29 @@ const EmptyState: React.FC = () => {
         <div className="mt-8 grid grid-cols-2 gap-4 text-left">
           <div className="bg-blue-50 rounded-lg p-4">
             <div className="text-2xl mb-2">🏃‍♂️</div>
-            <h4 className="font-medium text-gray-900 mb-1">Get Active</h4>
-            <p className="text-sm text-gray-600">
+            <h4 className="font-medium text-[var(--text)] mb-1">Get Active</h4>
+            <p className="text-sm text-muted">
               Set a daily step goal or workout routine
             </p>
           </div>
           <div className="bg-purple-50 rounded-lg p-4">
             <div className="text-2xl mb-2">📚</div>
-            <h4 className="font-medium text-gray-900 mb-1">Learn More</h4>
-            <p className="text-sm text-gray-600">
+            <h4 className="font-medium text-[var(--text)] mb-1">Learn More</h4>
+            <p className="text-sm text-muted">
               Read books or practice a new skill daily
             </p>
           </div>
           <div className="bg-green-50 rounded-lg p-4">
             <div className="text-2xl mb-2">🧘‍♀️</div>
-            <h4 className="font-medium text-gray-900 mb-1">Find Balance</h4>
-            <p className="text-sm text-gray-600">
+            <h4 className="font-medium text-[var(--text)] mb-1">Find Balance</h4>
+            <p className="text-sm text-muted">
               Meditate or journal for mental wellness
             </p>
           </div>
           <div className="bg-orange-50 rounded-lg p-4">
             <div className="text-2xl mb-2">💰</div>
-            <h4 className="font-medium text-gray-900 mb-1">Save Smart</h4>
-            <p className="text-sm text-gray-600">
+            <h4 className="font-medium text-[var(--text)] mb-1">Save Smart</h4>
+            <p className="text-sm text-muted">
               Track spending or build savings habits
             </p>
           </div>

--- a/frontend/src/features/goals/components/display/GoalCard.tsx
+++ b/frontend/src/features/goals/components/display/GoalCard.tsx
@@ -23,7 +23,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
         return (
           <div className="space-y-1">
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">Today's Progress</span>
+              <span className="text-muted">Today's Progress</span>
               <span className="font-medium">
                 {goal.progress.currentPeriodValue || 0} / {formatGoalValue(goal.target.value, goal.target.unit)}
               </span>
@@ -52,14 +52,14 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
                   {goal.progress.currentStreak || 0}
                 </span>
               </div>
-              <p className="text-xs text-gray-600">Current Streak</p>
+              <p className="text-xs text-muted">Current Streak</p>
             </div>
             {goal.progress.longestStreak && goal.progress.longestStreak > 0 && (
               <div className="text-center">
-                <div className="text-lg font-semibold text-gray-700">
+                <div className="text-lg font-semibold text-theme">
                   {goal.progress.longestStreak}
                 </div>
-                <p className="text-xs text-gray-600">Best Streak</p>
+                <p className="text-xs text-muted">Best Streak</p>
               </div>
             )}
           </div>
@@ -70,7 +70,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
         return (
           <div className="space-y-1">
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">Progress</span>
+              <span className="text-muted">Progress</span>
               <span className={`font-medium ${progressColor}`}>
                 {goal.progress.percentComplete.toFixed(0)}%
               </span>
@@ -81,7 +81,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
                 style={{ width: `${Math.min(goal.progress.percentComplete, 100)}%` }}
               />
             </div>
-            <div className="flex items-center justify-between text-xs text-gray-500">
+            <div className="flex items-center justify-between text-xs text-muted">
               <span>
                 {goal.progress.totalAccumulated || 0} / {formatGoalValue(goal.target.value, goal.target.unit)}
               </span>
@@ -97,7 +97,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
         return (
           <div className="space-y-1">
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">Current {goal.target.period}</span>
+              <span className="text-muted">Current {goal.target.period}</span>
               <span className={`font-medium ${isOverLimit ? 'text-red-600' : 'text-green-600'}`}>
                 {goal.progress.currentPeriodValue || 0} / {formatGoalValue(goal.target.value, goal.target.unit)}
               </span>
@@ -119,7 +119,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
   return (
     <div
       className={`
-        bg-white rounded-lg shadow-sm border-2 border-l-4 p-4 hover:shadow-md transition-shadow
+        bg-surface text-theme rounded-lg shadow-sm border-2 border-l-4 p-4 hover:shadow-md transition-shadow
         ${goal.status === 'paused' ? 'opacity-75' : ''}
       `}
       style={{ borderLeftColor: goal.color || pattern.color }}
@@ -133,12 +133,12 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
             </span>
             <Link
               to={`/goals/${goal.goalId}`}
-              className="font-semibold text-gray-900 hover:text-primary-600 transition-colors"
+              className="font-semibold text-theme hover:text-primary-600 transition-colors"
             >
               {goal.title}
             </Link>
             {category && (
-              <span className="text-xs px-2 py-1 bg-gray-100 text-gray-600 rounded-full">
+              <span className="text-xs px-2 py-1 bg-[var(--surface-muted)] text-muted rounded-full">
                 {category.label}
               </span>
             )}
@@ -146,14 +146,14 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
 
           {/* Description */}
           {goal.description && (
-            <p className="text-sm text-gray-600 mb-3 line-clamp-2">{goal.description}</p>
+            <p className="text-sm text-muted mb-3 line-clamp-2">{goal.description}</p>
           )}
 
           {/* Progress Display */}
           {renderProgressByPattern()}
 
           {/* Stats Row */}
-          <div className="flex items-center gap-4 mt-3 text-sm text-gray-500">
+          <div className="flex items-center gap-4 mt-3 text-sm text-muted">
             <span className="flex items-center gap-1">
               <span className="font-medium">{goal.progress.successRate}%</span>
               <span>success</span>
@@ -261,7 +261,7 @@ const GoalCard: React.FC<GoalCardProps> = ({ goal, onQuickLog, onEdit, onArchive
               text-xs px-2 py-1 rounded-full font-medium
               ${goal.status === 'completed' ? 'bg-green-100 text-green-800' : ''}
               ${goal.status === 'paused' ? 'bg-yellow-100 text-yellow-800' : ''}
-              ${goal.status === 'archived' ? 'bg-gray-100 text-gray-800' : ''}
+              ${goal.status === 'archived' ? 'bg-[var(--surface-muted)] text-gray-800' : ''}
             `}
           >
             {goal.status}

--- a/frontend/src/features/goals/components/display/GoalList.tsx
+++ b/frontend/src/features/goals/components/display/GoalList.tsx
@@ -17,7 +17,7 @@ const GoalList: React.FC<GoalListProps> = ({ goals, isLoading, onQuickLog, onEdi
     return (
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="bg-white rounded-lg shadow-sm border-2 p-4 animate-pulse">
+          <div key={i} className="bg-[var(--surface)] rounded-lg shadow-sm border-2 p-4 animate-pulse">
             <div className="flex items-start justify-between">
               <div className="flex-1 space-y-3">
                 <div className="flex items-center gap-2">

--- a/frontend/src/features/goals/components/logging/EnhancedActivityLog.tsx
+++ b/frontend/src/features/goals/components/logging/EnhancedActivityLog.tsx
@@ -128,14 +128,14 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-          <div className="absolute inset-0 bg-gray-500 opacity-75" onClick={onClose}></div>
+          <div className="absolute inset-0 bg-black/60" onClick={onClose}></div>
         </div>
 
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
           &#8203;
         </span>
 
-        <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full sm:p-6">
+        <div className="inline-block align-bottom bg-[var(--surface)] rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full sm:p-6">
           {goalLoading || !goal ? (
             <div className="text-center py-8">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
@@ -143,12 +143,12 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
           ) : (
             <>
               <div className="mb-4">
-                <h3 className="text-lg font-medium text-gray-900">Log Activity</h3>
-                <p className="mt-1 text-sm text-gray-600">{goal.title}</p>
+                <h3 className="text-lg font-medium text-[var(--text)]">Log Activity</h3>
+                <p className="mt-1 text-sm text-muted">{goal.title}</p>
               </div>
 
               {/* Tab Navigation */}
-              <div className="flex border-b border-gray-200 mb-4">
+              <div className="flex border-b border-[color:var(--surface-muted)] mb-4">
                 <button
                   type="button"
                   onClick={() => setActiveTab('quick')}
@@ -192,7 +192,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                             ${
                               activityType === type
                                 ? 'bg-primary-100 text-primary-800 border-primary-300'
-                                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                                : 'bg-[var(--surface)] text-gray-700 border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                             }
                             border
                           `}
@@ -233,7 +233,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                       step="any"
                       autoFocus
                     />
-                    <span className="text-gray-600">{goal.target.unit}</span>
+                    <span className="text-muted">{goal.target.unit}</span>
                   </div>
                   {goal.target.period && (
                     <p className="mt-1 text-xs text-gray-500">
@@ -251,7 +251,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                     value={note}
                     onChange={(e) => setNote(e.target.value)}
                     rows={2}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-primary-500 focus:border-primary-500"
                     placeholder="How did it go?"
                   />
                 </div>
@@ -278,7 +278,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                                 ${
                                   timeOfDay === option.value
                                     ? 'bg-primary-100 text-primary-800 border-primary-300'
-                                    : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                                    : 'bg-[var(--surface)] text-muted border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                                 }
                                 border
                               `}
@@ -298,7 +298,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                                 ${
                                   timeOfDay === option.value
                                     ? 'bg-primary-100 text-primary-800 border-primary-300'
-                                    : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                                    : 'bg-[var(--surface)] text-muted border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                                 }
                                 border
                               `}
@@ -326,7 +326,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                                 ${
                                   location === option.value
                                     ? 'bg-primary-100 text-primary-800 border-primary-300'
-                                    : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                                    : 'bg-[var(--surface)] text-muted border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                                 }
                                 border
                               `}
@@ -346,7 +346,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                                 ${
                                   location === option.value
                                     ? 'bg-primary-100 text-primary-800 border-primary-300'
-                                    : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                                    : 'bg-[var(--surface)] text-muted border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                                 }
                                 border
                               `}
@@ -396,7 +396,7 @@ const EnhancedActivityLog: React.FC<EnhancedActivityLogProps> = ({ goalId, isOpe
                                 ${
                                   mood === option.value
                                     ? 'bg-primary-100 ring-2 ring-primary-300'
-                                    : 'bg-gray-50 hover:bg-gray-100'
+                                    : 'bg-[var(--surface-muted)] hover:bg-[color:var(--surface-muted)]'
                                 }
                               `}
                               title={option.label}

--- a/frontend/src/features/goals/components/logging/QuickLogModal.tsx
+++ b/frontend/src/features/goals/components/logging/QuickLogModal.tsx
@@ -88,14 +88,14 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-          <div className="absolute inset-0 bg-gray-500 opacity-75" onClick={onClose}></div>
+          <div className="absolute inset-0 bg-black/60" onClick={onClose}></div>
         </div>
 
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
           &#8203;
         </span>
 
-        <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+        <div className="inline-block align-bottom bg-surface text-theme rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
           {goalLoading || !goal ? (
             <div className="text-center py-8">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
@@ -103,8 +103,8 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
           ) : (
             <>
               <div className="mb-4">
-                <h3 className="text-lg font-medium text-gray-900">Log Activity</h3>
-                <p className="mt-1 text-sm text-gray-600">{goal.title}</p>
+                <h3 className="text-lg font-medium text-theme">Log Activity</h3>
+                <p className="mt-1 text-sm text-muted">{goal.title}</p>
               </div>
 
               {error && (
@@ -119,7 +119,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
               <form onSubmit={handleSubmit} className="space-y-4">
                 {/* Activity Type */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-sm font-medium text-theme mb-2">
                     Activity Type
                   </label>
                   <div className="grid grid-cols-2 gap-2">
@@ -133,7 +133,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
                           ${
                             activityType === type
                               ? 'bg-primary-100 text-primary-800 border-primary-300'
-                              : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                              : 'bg-surface text-muted border-[color:var(--surface-muted)] hover:bg-[color:var(--surface-muted)] dark:hover:bg-gray-700'
                           }
                           border
                         `}
@@ -146,7 +146,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
 
                 {/* Value Input */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-theme mb-1">
                     Value
                   </label>
                   <div className="flex items-center space-x-2">
@@ -160,10 +160,10 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
                       step="any"
                       autoFocus
                     />
-                    <span className="text-gray-600">{goal.target.unit}</span>
+                    <span className="text-muted">{goal.target.unit}</span>
                   </div>
                   {goal.target.period && (
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-muted">
                       Target: {formatGoalValue(goal.target.value, goal.target.unit)} per {goal.target.period}
                     </p>
                   )}
@@ -171,7 +171,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
 
                 {/* Date Picker */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-theme mb-1">
                     Date
                   </label>
                   <Input
@@ -184,14 +184,14 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
 
                 {/* Quick Note */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-theme mb-1">
                     Note (optional)
                   </label>
                   <textarea
                     value={note}
                     onChange={(e) => setNote(e.target.value)}
                     rows={2}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-[color:var(--surface-muted)] rounded-md focus:ring-primary-500 focus:border-primary-500"
                     placeholder="How did it go?"
                   />
                 </div>
@@ -217,10 +217,10 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
 
                 {/* Advanced Context Fields */}
                 {showAdvanced && (
-                  <div className="space-y-4 pt-2 border-t border-gray-200">
+                  <div className="space-y-4 pt-2 border-t border-[color:var(--surface-muted)]">
                     {/* Mood */}
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-theme mb-2">
                         Mood
                       </label>
                       <div className="flex gap-2">
@@ -239,7 +239,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
                               flex flex-col items-center p-2 rounded-lg border-2 transition-all
                               ${mood === moodOption.label 
                                 ? 'border-primary-500 bg-primary-50' 
-                                : 'border-gray-200 hover:border-gray-300'
+                                : 'border-[color:var(--surface-muted)] hover:border-[color:var(--surface-muted)]'
                               }
                             `}
                           >
@@ -252,7 +252,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
 
                     {/* Energy Level */}
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-2">
+                      <label className="block text-sm font-medium text-theme mb-2">
                         Energy Level: {energyLevel}/10
                       </label>
                       <input
@@ -266,7 +266,7 @@ const QuickLogModal: React.FC<QuickLogModalProps> = ({ goalId, isOpen, onClose }
                           background: `linear-gradient(to right, #3B82F6 0%, #3B82F6 ${(energyLevel - 1) * 11.11}%, #E5E7EB ${(energyLevel - 1) * 11.11}%, #E5E7EB 100%)`
                         }}
                       />
-                      <div className="flex justify-between text-xs text-gray-500 mt-1">
+                      <div className="flex justify-between text-xs text-muted mt-1">
                         <span>Low</span>
                         <span>High</span>
                       </div>

--- a/frontend/src/features/journal/components/EditorSection.tsx
+++ b/frontend/src/features/journal/components/EditorSection.tsx
@@ -154,7 +154,7 @@ const EditorSection: React.FC<EditorSectionProps> = ({
         </div>
       )}
       {section.prompt && (
-        <div className="flex items-start gap-2 bg-gray-50 p-2 rounded text-sm italic">
+        <div className="flex items-start gap-2 bg-[var(--surface-muted)] p-2 rounded text-sm italic">
           <span role="img" aria-label="prompt">
             💡
           </span>

--- a/frontend/src/features/journal/components/JournalEditor.tsx
+++ b/frontend/src/features/journal/components/JournalEditor.tsx
@@ -111,7 +111,7 @@ const JournalEditor: React.FC<JournalEditorProps> = ({
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleBold().run()}
-          className={`p-1 rounded hover:bg-gray-200 ${editor.isActive('bold') ? 'bg-gray-300' : ''}`}
+          className={`p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${editor.isActive('bold') ? 'bg-gray-300 dark:bg-gray-600' : ''}`}
           aria-label="Toggle bold"
           title="Bold"
         >
@@ -120,7 +120,7 @@ const JournalEditor: React.FC<JournalEditorProps> = ({
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleItalic().run()}
-          className={`p-1 rounded hover:bg-gray-200 ${editor.isActive('italic') ? 'bg-gray-300' : ''}`}
+          className={`p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${editor.isActive('italic') ? 'bg-gray-300 dark:bg-gray-600' : ''}`}
           aria-label="Toggle italic"
           title="Italic"
         >
@@ -129,7 +129,7 @@ const JournalEditor: React.FC<JournalEditorProps> = ({
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-          className={`p-1 rounded hover:bg-gray-200 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-300' : ''}`}
+          className={`p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-300 dark:bg-gray-600' : ''}`}
           aria-label="Toggle heading"
           title="Heading"
         >
@@ -138,7 +138,7 @@ const JournalEditor: React.FC<JournalEditorProps> = ({
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleBulletList().run()}
-          className={`p-1 rounded hover:bg-gray-200 ${editor.isActive('bulletList') ? 'bg-gray-300' : ''}`}
+          className={`p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${editor.isActive('bulletList') ? 'bg-gray-300 dark:bg-gray-600' : ''}`}
           aria-label="Toggle bullet list"
           title="Bullet list"
         >

--- a/frontend/src/features/journal/components/TemplatePicker/TemplatePicker.tsx
+++ b/frontend/src/features/journal/components/TemplatePicker/TemplatePicker.tsx
@@ -29,7 +29,7 @@ const TemplatePicker: React.FC<TemplatePickerProps> = ({ onSelect }) => {
     <div className="space-y-2">
       <button
         type="button"
-        className="border rounded p-2 w-full text-left hover:bg-gray-50"
+        className="border rounded p-2 w-full text-left hover:bg-[color:var(--surface-muted)]"
         onClick={() => onSelect(null)}
         aria-label="Start from scratch"
       >
@@ -39,7 +39,7 @@ const TemplatePicker: React.FC<TemplatePickerProps> = ({ onSelect }) => {
         <button
           key={t.id}
           type="button"
-          className="border rounded p-2 w-full text-left hover:bg-gray-50"
+          className="border rounded p-2 w-full text-left hover:bg-[color:var(--surface-muted)]"
           onClick={() => onSelect(t)}
           aria-label={`${t.name} template`}
         >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import "./styles/theme.css";
 
 @layer base {
   :root {
@@ -8,9 +9,24 @@
   }
 
   body {
-    @apply bg-white text-gray-900;
     font-feature-settings: "rlig" 1, "calt" 1;
+    background: var(--bg);
+    color: var(--text);
   }
+
+  input,
+  textarea,
+  select {
+    background: var(--surface);
+    color: var(--text);
+    border-color: var(--surface-muted);
+  }
+
+  ::placeholder {
+    color: var(--text);
+    opacity: 0.6;
+  }
+
 }
 
 @layer utilities {
@@ -48,8 +64,27 @@
 /* Form input focus styles */
 @layer components {
   .form-input {
-    @apply block w-full rounded-md border-gray-300 shadow-sm 
-           focus:border-primary-500 focus:ring-primary-500 sm:text-sm;
+    @apply block w-full rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm;
+    background-color: var(--surface);
+    color: var(--text);
+    border-color: rgba(0,0,0,0.15);
+  }
+
+  .form-select,
+  .form-textarea {
+    @apply block w-full rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm;
+    background-color: var(--surface);
+    color: var(--text);
+    border-color: rgba(0,0,0,0.15);
+  }
+
+  [data-theme="dark"] .form-input {
+    border-color: rgba(255,255,255,0.2);
+  }
+
+  [data-theme="dark"] .form-select,
+  [data-theme="dark"] .form-textarea {
+    border-color: rgba(255,255,255,0.2);
   }
   
   .form-input-error {
@@ -69,6 +104,26 @@
     );
     background-size: 1000% 100%;
     animation: shimmer 2s infinite linear;
+  }
+
+  .bg-surface {
+    background-color: var(--surface);
+  }
+
+  .bg-surface-muted {
+    background-color: var(--surface-muted);
+  }
+
+  .bg-background {
+    background-color: var(--bg);
+  }
+
+  .text-theme {
+    color: var(--text);
+  }
+
+  .text-muted {
+    color: color-mix(in srgb, var(--text), transparent 40%);
   }
   
   @keyframes shimmer {

--- a/frontend/src/pages/ComponentShowcase.tsx
+++ b/frontend/src/pages/ComponentShowcase.tsx
@@ -176,13 +176,13 @@ export const ComponentShowcase: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background text-theme">
         {/* Navigation */}
-        <nav className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-40">
+        <nav className="bg-surface shadow-sm border-b border-[color:var(--surface-muted)] sticky top-0 z-40 text-theme">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between h-16">
               <div className="flex items-center">
-                <h1 className="text-xl font-bold text-gray-900">
+                <h1 className="text-xl font-bold text-[var(--text)]">
                   AI Lifestyle App - Component Showcase
                 </h1>
               </div>
@@ -194,7 +194,7 @@ export const ComponentShowcase: React.FC = () => {
                     className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                       activeSection === section.id
                         ? 'bg-purple-100 text-purple-700'
-                        : 'text-gray-600 hover:text-gray-900'
+                        : 'text-muted hover:text-[var(--text)]'
                     }`}
                   >
                     {section.label}
@@ -209,11 +209,11 @@ export const ComponentShowcase: React.FC = () => {
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           {activeSection === 'overview' && (
             <div className="space-y-8">
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h2 className="text-2xl font-bold text-[var(--text)] mb-4">
                   Welcome to the Component Showcase
                 </h2>
-                <p className="text-gray-600 mb-6">
+                <p className="text-muted mb-6">
                   This is a demonstration of all the UI components built for the AI Lifestyle App.
                   Navigate through the sections above to explore different component categories.
                 </p>
@@ -248,26 +248,26 @@ export const ComponentShowcase: React.FC = () => {
                 </div>
               </div>
               
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">
                   Implementation Status
                 </h3>
                 <div className="grid grid-cols-4 gap-4">
                   <div className="text-center">
                     <div className="text-3xl font-bold text-purple-600">✅</div>
-                    <div className="text-sm text-gray-600">2FA Complete</div>
+                    <div className="text-sm text-muted">2FA Complete</div>
                   </div>
                   <div className="text-center">
                     <div className="text-3xl font-bold text-blue-600">🔄</div>
-                    <div className="text-sm text-gray-600">Goals In Progress</div>
+                    <div className="text-sm text-muted">Goals In Progress</div>
                   </div>
                   <div className="text-center">
                     <div className="text-3xl font-bold text-green-600">100%</div>
-                    <div className="text-sm text-gray-600">TypeScript</div>
+                    <div className="text-sm text-muted">TypeScript</div>
                   </div>
                   <div className="text-center">
                     <div className="text-3xl font-bold text-orange-600">A11y</div>
-                    <div className="text-sm text-gray-600">Accessible</div>
+                    <div className="text-sm text-muted">Accessible</div>
                   </div>
                 </div>
               </div>
@@ -276,11 +276,11 @@ export const ComponentShowcase: React.FC = () => {
 
           {activeSection === 'encryption' && (
             <div className="space-y-8">
-              <h2 className="text-2xl font-bold text-gray-900">Encryption Components</h2>
+              <h2 className="text-2xl font-bold text-[var(--text)]">Encryption Components</h2>
               
               {/* Encryption Toggle */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Encryption Toggle</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Encryption Toggle</h3>
                 <EncryptionToggle
                   value={encryptionEnabled}
                   onChange={setEncryptionEnabled}
@@ -289,8 +289,8 @@ export const ComponentShowcase: React.FC = () => {
               </div>
               
               {/* Encryption Indicators */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Encryption Indicators</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Encryption Indicators</h3>
                 <div className="flex items-center gap-4">
                   <EncryptionIndicator status="encrypted" module="Journal" showLabel />
                   <EncryptionIndicator status="unencrypted" module="Goals" showLabel />
@@ -300,8 +300,8 @@ export const ComponentShowcase: React.FC = () => {
               </div>
               
               {/* Share Dialog Demo */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Share Dialog</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Share Dialog</h3>
                 <button
                   onClick={() => setShowShareDialog(true)}
                   className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
@@ -325,8 +325,8 @@ export const ComponentShowcase: React.FC = () => {
               </div>
               
               {/* Key Management */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Key Management</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Key Management</h3>
                 <KeyManagement
                   hasBackup={false}
                   onBackup={async () => console.log('Backup created')}
@@ -338,11 +338,11 @@ export const ComponentShowcase: React.FC = () => {
 
           {activeSection === 'goal-components' && (
             <div className="space-y-8">
-              <h2 className="text-2xl font-bold text-gray-900">Goal Components</h2>
+              <h2 className="text-2xl font-bold text-[var(--text)]">Goal Components</h2>
               
               {/* Pattern Selector */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Pattern Selector</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Pattern Selector</h3>
                 <PatternSelector 
                   onSelect={(pattern) => {
                     console.log('Selected pattern:', pattern);
@@ -353,8 +353,8 @@ export const ComponentShowcase: React.FC = () => {
               </div>
 
               {/* Goal List */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Goal List</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Goal List</h3>
                 <GoalList 
                   goals={mockGoals}
                   isLoading={false}
@@ -363,8 +363,8 @@ export const ComponentShowcase: React.FC = () => {
               </div>
 
               {/* Goal Cards */}
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Goal Cards</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Goal Cards</h3>
                 <div className="space-y-4">
                   {mockGoals.map(goal => (
                     <GoalCard 
@@ -389,10 +389,10 @@ export const ComponentShowcase: React.FC = () => {
 
           {activeSection === 'journal' && (
             <div className="space-y-8">
-              <h2 className="text-2xl font-bold text-gray-900">Journal Components</h2>
+              <h2 className="text-2xl font-bold text-[var(--text)]">Journal Components</h2>
 
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Journal Editor</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Journal Editor</h3>
                 <JournalEditor
                   initialContent={journalContent}
                   onSave={(md) => {
@@ -402,17 +402,17 @@ export const ComponentShowcase: React.FC = () => {
                 />
                 <div className="mt-4">
                   <h4 className="font-semibold text-gray-700 mb-2">Saved Markdown</h4>
-                  <pre className="p-2 bg-gray-100 rounded border text-sm whitespace-pre-wrap">{journalContent}</pre>
+                  <pre className="p-2 bg-[var(--surface-muted)] rounded border text-sm whitespace-pre-wrap">{journalContent}</pre>
                 </div>
               </div>
 
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Journal Storage Sample</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Journal Storage Sample</h3>
                 <JournalStorageSample />
               </div>
 
-              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Template Picker Demo</h3>
+              <div className="bg-surface rounded-lg shadow-sm border border-[color:var(--surface-muted)] p-6">
+                <h3 className="text-lg font-semibold text-[var(--text)] mb-4">Template Picker Demo</h3>
                 <JournalTemplateDemo />
               </div>
             </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,10 +5,10 @@ const DashboardPage: React.FC = () => {
   const { user } = useAuth();
 
   return (
-    <div>
+    <div className="text-theme">
       <div className="md:flex md:items-center md:justify-between">
         <div className="flex-1 min-w-0">
-          <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
+          <h2 className="text-2xl font-bold leading-7 text-theme sm:text-3xl sm:truncate">
             Welcome back, {user?.firstName}!
           </h2>
         </div>
@@ -16,7 +16,7 @@ const DashboardPage: React.FC = () => {
 
       <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
         {/* Stats Cards */}
-        <div className="bg-white overflow-hidden shadow rounded-lg">
+        <div className="bg-surface overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -27,14 +27,14 @@ const DashboardPage: React.FC = () => {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Today's Meals</dt>
-                  <dd className="text-lg font-medium text-gray-900">0</dd>
+                  <dd className="text-lg font-medium text-theme">0</dd>
                 </dl>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="bg-white overflow-hidden shadow rounded-lg">
+        <div className="bg-surface overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -45,14 +45,14 @@ const DashboardPage: React.FC = () => {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Workouts This Week</dt>
-                  <dd className="text-lg font-medium text-gray-900">0</dd>
+                  <dd className="text-lg font-medium text-theme">0</dd>
                 </dl>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="bg-white overflow-hidden shadow rounded-lg">
+        <div className="bg-surface overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -63,14 +63,14 @@ const DashboardPage: React.FC = () => {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Wellness Score</dt>
-                  <dd className="text-lg font-medium text-gray-900">--</dd>
+                  <dd className="text-lg font-medium text-theme">--</dd>
                 </dl>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="bg-white overflow-hidden shadow rounded-lg">
+        <div className="bg-surface overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -81,7 +81,7 @@ const DashboardPage: React.FC = () => {
               <div className="ml-5 w-0 flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">Active Routines</dt>
-                  <dd className="text-lg font-medium text-gray-900">0</dd>
+                  <dd className="text-lg font-medium text-theme">0</dd>
                 </dl>
               </div>
             </div>
@@ -91,9 +91,9 @@ const DashboardPage: React.FC = () => {
 
       {/* Quick Actions */}
       <div className="mt-8">
-        <h3 className="text-lg leading-6 font-medium text-gray-900">Quick Actions</h3>
+        <h3 className="text-lg leading-6 font-medium text-theme">Quick Actions</h3>
         <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <button className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
+          <button className="relative rounded-lg border border-[color:var(--surface-muted)] bg-surface px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
             <div className="flex-shrink-0">
               <svg className="h-10 w-10 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -101,12 +101,12 @@ const DashboardPage: React.FC = () => {
             </div>
             <div className="flex-1 min-w-0">
               <span className="absolute inset-0" aria-hidden="true" />
-              <p className="text-sm font-medium text-gray-900">Log a Meal</p>
+              <p className="text-sm font-medium text-theme">Log a Meal</p>
               <p className="text-sm text-gray-500">Track your nutrition</p>
             </div>
           </button>
 
-          <button className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
+          <button className="relative rounded-lg border border-[color:var(--surface-muted)] bg-surface px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
             <div className="flex-shrink-0">
               <svg className="h-10 w-10 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -114,12 +114,12 @@ const DashboardPage: React.FC = () => {
             </div>
             <div className="flex-1 min-w-0">
               <span className="absolute inset-0" aria-hidden="true" />
-              <p className="text-sm font-medium text-gray-900">Start Workout</p>
+              <p className="text-sm font-medium text-theme">Start Workout</p>
               <p className="text-sm text-gray-500">Begin exercise session</p>
             </div>
           </button>
 
-          <button className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
+          <button className="relative rounded-lg border border-[color:var(--surface-muted)] bg-surface px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-primary-500">
             <div className="flex-shrink-0">
               <svg className="h-10 w-10 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -127,7 +127,7 @@ const DashboardPage: React.FC = () => {
             </div>
             <div className="flex-1 min-w-0">
               <span className="absolute inset-0" aria-hidden="true" />
-              <p className="text-sm font-medium text-gray-900">Check In</p>
+              <p className="text-sm font-medium text-theme">Check In</p>
               <p className="text-sm text-gray-500">Daily wellness update</p>
             </div>
           </button>
@@ -135,10 +135,10 @@ const DashboardPage: React.FC = () => {
       </div>
 
       {/* Account Status */}
-      <div className="mt-8 bg-white shadow rounded-lg">
+      <div className="mt-8 bg-surface shadow rounded-lg">
         <div className="px-4 py-5 sm:p-6">
-          <h3 className="text-lg leading-6 font-medium text-gray-900">Account Status</h3>
-          <div className="mt-3 max-w-xl text-sm text-gray-600">
+          <h3 className="text-lg leading-6 font-medium text-theme">Account Status</h3>
+          <div className="mt-3 max-w-xl text-sm text-muted">
             <p>Your account security status and settings.</p>
           </div>
           <div className="mt-5 space-y-3">
@@ -146,7 +146,7 @@ const DashboardPage: React.FC = () => {
               <svg className="h-5 w-5 text-green-500 mr-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted">
                 Email verified: {user?.emailVerified ? 'Yes' : 'No'}
               </span>
             </div>
@@ -154,7 +154,7 @@ const DashboardPage: React.FC = () => {
               <svg className={`h-5 w-5 ${user?.mfaEnabled ? 'text-green-500' : 'text-gray-400'} mr-2`} fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted">
                 Two-factor authentication: {user?.mfaEnabled ? 'Enabled' : 'Disabled'}
               </span>
             </div>

--- a/frontend/src/pages/DebugPage.tsx
+++ b/frontend/src/pages/DebugPage.tsx
@@ -3,7 +3,7 @@ import ApiDebugger from '../components/debug/ApiDebugger';
 
 const DebugPage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background text-theme">
       <div className="container mx-auto py-8">
         <h1 className="text-3xl font-bold text-center mb-8">Debug Dashboard</h1>
         <ApiDebugger />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ThemeSwitcher } from '../components/common';
+
+const SettingsPage: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-semibold mb-4">Settings</h1>
+      <div className="space-y-4">
+        <label className="block">
+          <span className="text-theme">Theme</span>
+          <div className="mt-1">
+            <ThemeSwitcher />
+          </div>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/frontend/src/pages/auth/LoginPage.debug.tsx
+++ b/frontend/src/pages/auth/LoginPage.debug.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 const LoginPage: React.FC = () => {
 
   return (
-    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-gray-50">
+    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-background text-theme">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h1 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        <h1 className="mt-6 text-center text-3xl font-extrabold text-theme">
           AI Lifestyle App - Debug Mode
         </h1>
       </div>
 
       <div className="mt-8 w-full max-w-md mx-auto">
-        <div className="bg-white py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
-          <h2 className="text-center text-2xl font-bold text-gray-900 mb-6">
+        <div className="bg-surface py-8 px-4 shadow-lg sm:rounded-lg sm:px-10">
+          <h2 className="text-center text-2xl font-bold text-[var(--text)] mb-6">
             Login Form Loading Test
           </h2>
           

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -29,9 +29,9 @@ const LoginPage: React.FC = () => {
   }, [searchParams]);
 
   return (
-    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-gray-50">
+    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-background text-theme">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h1 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        <h1 className="mt-6 text-center text-3xl font-extrabold text-theme">
           AI Lifestyle App
         </h1>
       </div>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -3,14 +3,14 @@ import RegistrationForm from '../../features/auth/components/RegistrationForm';
 
 const RegisterPage: React.FC = () => {
   return (
-    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-gray-50">
+    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-background text-theme">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <img
           className="mx-auto h-12 w-auto"
           src="/logo.svg"
           alt="AI Lifestyle App"
         />
-        <h1 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        <h1 className="mt-6 text-center text-3xl font-extrabold text-theme">
           AI Lifestyle App
         </h1>
       </div>

--- a/frontend/src/pages/goals/CreateGoalPage.tsx
+++ b/frontend/src/pages/goals/CreateGoalPage.tsx
@@ -3,7 +3,7 @@ import GoalWizard from '../../features/goals/components/creation/GoalWizard';
 
 const CreateGoalPage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-background text-theme py-8">
       <GoalWizard />
     </div>
   );

--- a/frontend/src/pages/goals/GoalsPage.tsx
+++ b/frontend/src/pages/goals/GoalsPage.tsx
@@ -96,8 +96,8 @@ const GoalsPage: React.FC = () => {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">My Goals</h1>
-          <p className="mt-1 text-gray-600">Track your progress and stay motivated</p>
+          <h1 className="text-3xl font-bold text-[var(--text)]">My Goals</h1>
+          <p className="mt-1 text-muted">Track your progress and stay motivated</p>
         </div>
         <Link to="/goals/new">
           <Button size="lg" className="flex items-center">
@@ -110,7 +110,7 @@ const GoalsPage: React.FC = () => {
       </div>
 
       {/* Tabs */}
-      <div className="bg-white rounded-t-lg shadow-sm border-b border-gray-200">
+      <div className="bg-surface rounded-t-lg shadow-sm border-b border-[color:var(--surface-muted)]">
         <div className="flex">
           <button
             onClick={() => setActiveTab('active')}
@@ -118,13 +118,13 @@ const GoalsPage: React.FC = () => {
               px-6 py-3 font-medium text-sm border-b-2 transition-colors
               ${activeTab === 'active' 
                 ? 'text-primary-600 border-primary-600' 
-                : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300'
+                : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-[color:var(--surface-muted)]'
               }
             `}
           >
             Active Goals
             {allGoalsData && (
-              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-600">
+              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-[var(--surface-muted)] text-muted">
                 {allGoalsData.goals.filter(g => g.status === 'active' || g.status === 'paused').length}
               </span>
             )}
@@ -135,13 +135,13 @@ const GoalsPage: React.FC = () => {
               px-6 py-3 font-medium text-sm border-b-2 transition-colors
               ${activeTab === 'archived' 
                 ? 'text-primary-600 border-primary-600' 
-                : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300'
+                : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-[color:var(--surface-muted)]'
               }
             `}
           >
             Archived
             {allGoalsData && (
-              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-600">
+              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-[var(--surface-muted)] text-muted">
                 {allGoalsData.goals.filter(g => g.status === 'archived' || g.status === 'completed').length}
               </span>
             )}
@@ -150,7 +150,7 @@ const GoalsPage: React.FC = () => {
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-b-lg shadow-sm p-4 mb-6">
+      <div className="bg-surface rounded-b-lg shadow-sm p-4 mb-6">
         <div className="space-y-4">
           {activeTab === 'active' ? (
             /* Status Filter for Active Tab */
@@ -169,7 +169,7 @@ const GoalsPage: React.FC = () => {
                     px-3 py-1 rounded-full text-sm font-medium transition-all
                     ${selectedStatuses.includes('active')
                       ? 'bg-green-100 text-green-800'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                 >
@@ -187,7 +187,7 @@ const GoalsPage: React.FC = () => {
                     px-3 py-1 rounded-full text-sm font-medium transition-all
                     ${selectedStatuses.includes('paused')
                       ? 'bg-yellow-100 text-yellow-800'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                 >
@@ -212,7 +212,7 @@ const GoalsPage: React.FC = () => {
                     px-3 py-1 rounded-full text-sm font-medium transition-all
                     ${selectedStatuses.includes('completed')
                       ? 'bg-blue-100 text-blue-800'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                 >
@@ -229,8 +229,8 @@ const GoalsPage: React.FC = () => {
                   className={`
                     px-3 py-1 rounded-full text-sm font-medium transition-all
                     ${selectedStatuses.includes('archived')
-                      ? 'bg-gray-100 text-gray-800'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      ? 'bg-[var(--surface-muted)] text-gray-800'
+                      : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                 >
@@ -253,7 +253,7 @@ const GoalsPage: React.FC = () => {
                     ${
                       selectedPatterns.includes(pattern.id)
                         ? 'text-white'
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                        : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                   style={{
@@ -280,7 +280,7 @@ const GoalsPage: React.FC = () => {
                     ${
                       selectedCategories.includes(category.value)
                         ? 'bg-primary-100 text-primary-800'
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                        : 'bg-[var(--surface-muted)] text-muted hover:bg-gray-200'
                     }
                   `}
                 >
@@ -334,31 +334,31 @@ const GoalsPage: React.FC = () => {
       {/* Stats Summary */}
       {data && data.goals.length > 0 && (
         <div className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-white rounded-lg shadow-sm p-4 text-center">
-            <div className="text-2xl font-bold text-gray-900">
+          <div className="bg-surface rounded-lg shadow-sm p-4 text-center">
+            <div className="text-2xl font-bold text-[var(--text)]">
               {data.goals.filter((g) => g.status === 'active').length}
             </div>
-            <p className="text-sm text-gray-600">Active Goals</p>
+            <p className="text-sm text-muted">Active Goals</p>
           </div>
-          <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+          <div className="bg-surface rounded-lg shadow-sm p-4 text-center">
             <div className="text-2xl font-bold text-green-600">
               {data.goals.filter((g) => g.progress.percentComplete >= 100).length}
             </div>
-            <p className="text-sm text-gray-600">Achieved</p>
+            <p className="text-sm text-muted">Achieved</p>
           </div>
-          <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+          <div className="bg-surface rounded-lg shadow-sm p-4 text-center">
             <div className="text-2xl font-bold text-orange-600">
               {Math.max(...data.goals.map((g) => g.progress.currentStreak || 0))}
             </div>
-            <p className="text-sm text-gray-600">Best Streak</p>
+            <p className="text-sm text-muted">Best Streak</p>
           </div>
-          <div className="bg-white rounded-lg shadow-sm p-4 text-center">
+          <div className="bg-surface rounded-lg shadow-sm p-4 text-center">
             <div className="text-2xl font-bold text-primary-600">
               {Math.round(
                 data.goals.reduce((sum, g) => sum + g.progress.successRate, 0) / data.goals.length
               )}%
             </div>
-            <p className="text-sm text-gray-600">Avg Success Rate</p>
+            <p className="text-sm text-muted">Avg Success Rate</p>
           </div>
         </div>
       )}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,37 @@
+/* Theme palettes via CSS variables */
+
+/* Base (default dark theme) variables on :root */
+:root {
+  --bg: #0F172A;           /* dark background */
+  --surface: #1E293B;      /* dark surface */
+  --surface-muted: #334155;/* muted surface */
+  --text: #F1F5F9;         /* light text */
+  --accent: #60A5FA;       /* accent color */
+}
+
+/* Explicit dark attribute (same as root) */
+[data-theme="dark"] {
+  --bg: #0F172A;
+  --surface: #1E293B;
+  --surface-muted: #334155;
+  --text: #F1F5F9;
+  --accent: #60A5FA;
+}
+
+/* Light theme overrides */
+[data-theme="light"] {
+  --bg: #F9FAFC;
+  --surface: #FFFFFF;
+  --surface-muted: #F1F5F9;
+  --text: #111827;
+  --accent: #3B82F6;
+}
+
+/* Reading (solarized-style) theme */
+[data-theme="reading"] {
+  --bg: #FDF6E3;
+  --surface: #FFFDF6;
+  --surface-muted: #E2DDC7;
+  --text: #073642;
+  --accent: #268BD2;
+}

--- a/frontend/src/test/theme.integration.test.tsx
+++ b/frontend/src/test/theme.integration.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '../contexts';
+import App from '../App';
+
+test('applies reading theme to html and body', () => {
+  localStorage.setItem('theme-preference', 'reading');
+  render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+  const html = document.documentElement;
+  expect(html.dataset.theme).toBe('reading');
+  const bodyBg = getComputedStyle(document.body).backgroundColor;
+  expect(bodyBg).not.toBe('rgb(255, 255, 255)');
+});

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -42,7 +43,12 @@ export default {
           700: '#388e3c',
           800: '#2e7d32',
           900: '#1b5e20',
-        }
+        },
+        bg: 'var(--bg)',
+        text: 'var(--text)',
+        surface: 'var(--surface)',
+        'surface-muted': 'var(--surface-muted)',
+        accent: 'var(--accent)'
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'Avenir', 'Helvetica', 'Arial', 'sans-serif'],


### PR DESCRIPTION
## Summary
- refine theme palettes and include a 'reading' mode
- ensure ThemeProvider wraps the router for global styling
- add input text color and focus ring offset variables
- provide a settings picker for light, dark and reading themes
- update integration test for the reading theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: missing type declarations)*
- `make lint` *(no rule)*
- `make test` *(module import errors and NoRegionError)*

------
https://chatgpt.com/codex/tasks/task_e_68706bd186ec8328b716781aa2f72fab