### PR TITLE
Fix default title and favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AI Lifestyle App</title>
     <script>
       (function () {
         const stored = localStorage.getItem('theme-preference');


### PR DESCRIPTION
## Summary
- give the app a real name in `index.html`
- use our `logo.svg` instead of the default Vite icon

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test -- --run`
- `make lint` *(fails: module not installed)*
- `make test` *(fails: NoRegionError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6872891e40348328ae3893d0de7d7431