### PR TITLE
Fix theme not applied to layout backgrounds

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -7,7 +7,7 @@ const AppLayout: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-surface text-theme">
+    <div className="min-h-screen bg-background text-theme">
       <Header
         onMobileMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
       />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -36,7 +36,7 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuToggle }) => {
   };
 
   return (
-    <header className="bg-surface shadow">
+    <header className="bg-background shadow">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo and Desktop Navigation */}

--- a/frontend/src/components/layout/PublicLayout.tsx
+++ b/frontend/src/components/layout/PublicLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const PublicLayout: React.FC = () => {
   return (
-    <div className="min-h-screen bg-surface text-theme">
+    <div className="min-h-screen bg-background text-theme">
       <Outlet />
     </div>
   );


### PR DESCRIPTION
## Summary
- use `bg-background` on AppLayout and PublicLayout containers
- theme banner with `bg-background` as well

## Testing
- `make lint` *(fails: module not installed)*
- `make test` *(fails: NoRegionError during pytest collection)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68728f22b180832898ab4a5bfd708f16