### PR TITLE
Wire up goal analytics components

### DIFF
--- a/frontend/src/features/goals/index.ts
+++ b/frontend/src/features/goals/index.ts
@@ -5,6 +5,16 @@ export { default as GoalWizard } from './components/creation/GoalWizard';
 export { default as PatternSelector } from './components/creation/PatternSelector';
 export { default as QuickLogModal } from './components/logging/QuickLogModal';
 export { default as ActivityHistory } from './components/GoalProgress/ActivityHistory';
+export { default as EnhancedActivityLog } from './components/logging/EnhancedActivityLog';
+export {
+  ProgressRing,
+  GoalProgressRing,
+  MiniProgressRing,
+} from './components/GoalProgress/ProgressRing';
+export { StreakCalendar, StreakBadge } from './components/GoalProgress/StreakCalendar';
+export { default as ProgressCharts } from './components/GoalProgress/ProgressCharts';
+export { TrendLine } from './components/GoalProgress/TrendLine';
+export { MilestoneChart, MilestoneBar } from './components/GoalProgress/MilestoneChart';
 
 // Export types
 export * from './types/api.types';

--- a/frontend/src/pages/goals/GoalDetailPage.tsx
+++ b/frontend/src/pages/goals/GoalDetailPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGoalProgress } from '../../features/goals/hooks/useGoals';
 import {
   getGoal,
   listActivities,
@@ -33,6 +34,8 @@ const GoalDetailPage: React.FC = () => {
     enabled: !!goalId,
   });
 
+  const { data: progressData, isLoading: progLoading } = useGoalProgress(goalId!, 'current');
+
   const updateStatus = useMutation<void, Error, 'active' | 'paused' | 'completed' | 'archived'>({
     mutationFn: async (status) => {
       if (status === 'archived') {
@@ -57,7 +60,7 @@ const GoalDetailPage: React.FC = () => {
     },
   });
 
-  if (goalLoading || actLoading) {
+  if (goalLoading || actLoading || progLoading) {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8 text-center">Loading...</div>
     );
@@ -87,6 +90,7 @@ const GoalDetailPage: React.FC = () => {
       onLogActivity={(activity: Partial<GoalActivity>) =>
         logMutation.mutate(activity as LogActivityRequest)
       }
+      progressData={progressData}
     />
   );
 };


### PR DESCRIPTION
## Summary
- export analytics components from goals index
- fetch goal progress in GoalDetailPage
- display milestone and trend analytics in GoalDetail

## Testing
- `npx @apidevtools/swagger-cli validate contract/openapi.yaml` *(fails: schema errors)*
- `cd backend && make test` *(fails: ModuleNotFoundError and NoRegionError)*
- `cd backend && make lint` *(fails: Terraform modules not installed)*
- `cd frontend && npm run lint` *(fails: missing eslint deps)*
- `cd frontend && npm run type-check`
- `cd frontend && npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872924d3d34832881ef64525ee94924