### PR TITLE
Integrate encryption UI with theme system

### DIFF
--- a/frontend/src/components/EncryptionOnboarding.tsx
+++ b/frontend/src/components/EncryptionOnboarding.tsx
@@ -34,17 +34,17 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
 
   if (variant === "banner") {
     return (
-      <div className="bg-blue-50 border-b border-blue-200">
+      <div className="bg-[var(--accent-bg)] border-b border-[var(--accent)]/20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
           <div className="flex items-center justify-between flex-wrap">
             <div className="flex items-center flex-1">
-              <Shield className="h-5 w-5 text-blue-600 mr-3 flex-shrink-0" />
+              <Shield className="h-5 w-5 text-[var(--accent)] mr-3 flex-shrink-0" />
               <div className="flex-1">
-                <p className="text-sm font-medium text-blue-900">
+                <p className="text-sm font-medium text-[var(--text)]">
                   Secure your journal entries with end-to-end encryption
                 </p>
                 {showDetails && (
-                  <p className="text-sm text-blue-700 mt-1">
+                  <p className="text-sm text-[var(--text-muted)] mt-1">
                     Your entries will be encrypted before leaving your device.
                     Only you can decrypt them with your master password.
                   </p>
@@ -54,7 +54,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
             <div className="flex items-center space-x-2 mt-2 sm:mt-0">
               <button
                 onClick={() => setShowDetails(!showDetails)}
-                className="text-sm text-blue-600 hover:text-blue-700 px-2 py-1"
+                className="text-sm text-[var(--accent)] hover:text-[var(--accent-hover)] px-2 py-1"
               >
                 {showDetails ? "Less info" : "Learn more"}
               </button>
@@ -69,7 +69,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
               {onDismiss && (
                 <button
                   onClick={handleDismiss}
-                  className="text-blue-600 hover:text-blue-700 p-1"
+                  className="text-[var(--accent)] hover:text-[var(--accent-hover)] p-1"
                   aria-label="Dismiss"
                 >
                   <X className="h-4 w-4" />
@@ -85,13 +85,13 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
   // Modal variant
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-lg max-w-md w-full p-6">
+      <div className="bg-[var(--surface)] rounded-lg max-w-md w-full p-6">
         <div className="flex items-start justify-between mb-4">
           <div className="flex items-center">
-            <Shield className="h-8 w-8 text-blue-600 mr-3" />
+            <Shield className="h-8 w-8 text-[var(--accent)] mr-3" />
             <div>
-              <h2 className="text-xl font-bold">Protect Your Privacy</h2>
-              <p className="text-sm text-gray-600">
+              <h2 className="text-xl font-bold text-[var(--text)]">Protect Your Privacy</h2>
+              <p className="text-sm text-[var(--text-muted)]">
                 Set up encryption for your journal
               </p>
             </div>
@@ -99,7 +99,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
           {onDismiss && (
             <button
               onClick={handleDismiss}
-              className="text-gray-400 hover:text-gray-600"
+              className="text-[var(--text-muted)] hover:text-[var(--text)]"
               aria-label="Close"
             >
               <X className="h-5 w-5" />
@@ -108,11 +108,11 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
         </div>
 
         <div className="space-y-4">
-          <div className="bg-blue-50 rounded-lg p-4">
-            <h3 className="font-semibold text-blue-900 mb-2">
+          <div className="bg-[var(--accent-bg)] rounded-lg p-4">
+            <h3 className="font-semibold text-[var(--accent)] mb-2">
               Why use encryption?
             </h3>
-            <ul className="space-y-2 text-sm text-blue-800">
+            <ul className="space-y-2 text-sm text-[var(--text)]">
               <li className="flex items-start">
                 <Lock className="h-4 w-4 mt-0.5 mr-2 flex-shrink-0" />
                 <span>
@@ -132,8 +132,8 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
             </ul>
           </div>
 
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
-            <p className="text-sm text-yellow-800">
+          <div className="bg-[var(--warning-bg)] border border-[var(--warning)] rounded-lg p-3">
+            <p className="text-sm text-[var(--warning)]">
               <strong>Important:</strong> You'll create a master password
               separate from your login password. Store it safely - we cannot
               recover encrypted entries if you forget it.
@@ -143,7 +143,7 @@ export const EncryptionOnboarding: React.FC<EncryptionOnboardingProps> = ({
           <div className="flex justify-between items-center pt-2">
             <button
               onClick={handleDismiss}
-              className="text-gray-600 hover:text-gray-700"
+              className="text-[var(--text-muted)] hover:text-[var(--text)]"
             >
               Maybe later
             </button>

--- a/frontend/src/components/EncryptionUnlockPrompt.tsx
+++ b/frontend/src/components/EncryptionUnlockPrompt.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Lock } from "lucide-react";
 import { useEncryption } from "../contexts/useEncryption";
-import { Button } from "./common";
+import { Button, Input } from "./common";
 import { useNavigate } from "react-router-dom";
 import { securePasswordStorage } from "../services/encryption/securePasswordStorage";
 
@@ -55,35 +55,30 @@ export const EncryptionUnlockPrompt: React.FC = () => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-lg max-w-md w-full p-6">
+      <div className="bg-[var(--surface)] rounded-lg max-w-md w-full p-6">
         <div className="flex items-center mb-4">
-          <Lock className="h-8 w-8 text-yellow-600 mr-3" />
-          <h2 className="text-2xl font-bold">Unlock Encryption</h2>
+          <Lock className="h-8 w-8 text-[var(--warning)] mr-3" />
+          <h2 className="text-2xl font-bold text-[var(--text)]">Unlock Encryption</h2>
         </div>
 
         <div className="space-y-4">
           {isEncryptionSetup ? (
             <>
-              <p className="text-gray-600">
+              <p className="text-[var(--text-muted)]">
                 Enter your master encryption password to access encrypted
                 content.
               </p>
 
               <form onSubmit={handleUnlock} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Master Encryption Password
-                  </label>
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
-                    placeholder="Enter your master password"
-                    autoFocus
-                    required
-                  />
-                </div>
+                <Input
+                  label="Master Encryption Password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your master password"
+                  autoFocus
+                  required
+                />
 
                 <div className="flex items-center">
                   <input
@@ -91,19 +86,19 @@ export const EncryptionUnlockPrompt: React.FC = () => {
                     id="rememberPassword"
                     checked={rememberPassword}
                     onChange={(e) => setRememberPassword(e.target.checked)}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                    className="h-4 w-4 text-[var(--accent)] focus:ring-[var(--accent)] border-[var(--surface-muted)] rounded"
                   />
                   <label
                     htmlFor="rememberPassword"
-                    className="ml-2 text-sm text-gray-700"
+                    className="ml-2 text-sm text-[var(--text)]"
                   >
                     Remember password on this device (30 days)
                   </label>
                 </div>
 
                 {error && (
-                  <div className="bg-red-50 border border-red-200 rounded p-3">
-                    <p className="text-sm text-red-700">{error}</p>
+                  <div className="bg-[var(--error-bg)] border border-[var(--error)] rounded p-3">
+                    <p className="text-sm text-[var(--error)]">{error}</p>
                   </div>
                 )}
 
@@ -111,7 +106,7 @@ export const EncryptionUnlockPrompt: React.FC = () => {
                   <button
                     type="button"
                     onClick={handleGoToSettings}
-                    className="text-sm text-blue-600 hover:text-blue-700"
+                    className="text-sm text-[var(--accent)] hover:text-[var(--accent-hover)]"
                   >
                     Forgot password?
                   </button>
@@ -127,26 +122,21 @@ export const EncryptionUnlockPrompt: React.FC = () => {
             </>
           ) : (
             <>
-              <p className="text-gray-600">
+              <p className="text-[var(--text-muted)]">
                 Your encryption is set up on another device. Enter your master
                 password to access encrypted content on this device.
               </p>
 
               <form onSubmit={handleUnlock} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Master Encryption Password
-                  </label>
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
-                    placeholder="Enter your master password"
-                    autoFocus
-                    required
-                  />
-                </div>
+                <Input
+                  label="Master Encryption Password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your master password"
+                  autoFocus
+                  required
+                />
 
                 <div className="flex items-center">
                   <input
@@ -154,19 +144,19 @@ export const EncryptionUnlockPrompt: React.FC = () => {
                     id="rememberPassword"
                     checked={rememberPassword}
                     onChange={(e) => setRememberPassword(e.target.checked)}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                    className="h-4 w-4 text-[var(--accent)] focus:ring-[var(--accent)] border-[var(--surface-muted)] rounded"
                   />
                   <label
                     htmlFor="rememberPassword"
-                    className="ml-2 text-sm text-gray-700"
+                    className="ml-2 text-sm text-[var(--text)]"
                   >
                     Remember password on this device (30 days)
                   </label>
                 </div>
 
                 {error && (
-                  <div className="bg-red-50 border border-red-200 rounded p-3">
-                    <p className="text-sm text-red-700">{error}</p>
+                  <div className="bg-[var(--error-bg)] border border-[var(--error)] rounded p-3">
+                    <p className="text-sm text-[var(--error)]">{error}</p>
                   </div>
                 )}
 
@@ -174,7 +164,7 @@ export const EncryptionUnlockPrompt: React.FC = () => {
                   <button
                     type="button"
                     onClick={handleGoToSettings}
-                    className="text-sm text-red-600 hover:text-red-700"
+                    className="text-sm text-[var(--error)] hover:text-[var(--error)]/80"
                   >
                     Reset encryption
                   </button>

--- a/frontend/src/components/encryption/EncryptionSettings.tsx
+++ b/frontend/src/components/encryption/EncryptionSettings.tsx
@@ -29,10 +29,10 @@ export const EncryptionSettings: React.FC = () => {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-[var(--surface)] rounded-lg shadow p-6">
       <div className="flex items-center mb-4">
-        <Shield className="h-6 w-6 text-blue-600 mr-2" />
-        <h2 className="text-xl font-semibold">Encryption Settings</h2>
+        <Shield className="h-6 w-6 text-[var(--accent)] mr-2" />
+        <h2 className="text-xl font-semibold text-[var(--text)]">Encryption Settings</h2>
       </div>
 
       <div className="space-y-4">
@@ -41,8 +41,8 @@ export const EncryptionSettings: React.FC = () => {
           <h3 className="text-lg font-medium mb-2">Password Storage</h3>
 
           {hasStoredPassword ? (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <p className="text-sm text-blue-800 mb-3">
+            <div className="bg-[var(--accent-bg)] border border-[var(--accent)]/20 rounded-lg p-4">
+              <p className="text-sm text-[var(--text)] mb-3">
                 Your master password is securely stored on this device. It will
                 automatically expire after 30 days for security.
               </p>
@@ -57,8 +57,8 @@ export const EncryptionSettings: React.FC = () => {
               </Button>
             </div>
           ) : (
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <p className="text-sm text-gray-700">
+            <div className="bg-[var(--surface-muted)] border border-[var(--surface-muted)] rounded-lg p-4">
+              <p className="text-sm text-[var(--text)]">
                 No password is stored on this device. You can choose to remember
                 your password when unlocking encryption.
               </p>
@@ -69,7 +69,7 @@ export const EncryptionSettings: React.FC = () => {
         {/* Security Information */}
         <div className="border-t pt-4">
           <h3 className="text-lg font-medium mb-2">Security Information</h3>
-          <div className="space-y-2 text-sm text-gray-600">
+          <div className="space-y-2 text-sm text-[var(--text-muted)]">
             <p>• Stored passwords are encrypted using device-specific keys</p>
             <p>• Passwords expire automatically after 30 days</p>
             <p>• Clearing browser data will remove stored passwords</p>


### PR DESCRIPTION
## Summary
- apply theme tokens to `EncryptionUnlockPrompt` with Input component
- themeify `EncryptionOnboarding`
- update `EncryptionSettings` styling to use theme variables

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6884e54956148328ad93e81f6b9f8afd